### PR TITLE
docs: add smoke harness to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ cmake --build --preset linux-debug
 ./build/linux-debug/curlee run examples/mvp_run_control_flow.curlee
 ```
 
+### Smoke test
+
+For a quick end-to-end confidence loop (build + basic CLI + proof fixtures + a small targeted test run):
+
+```bash
+bash scripts/smoke.sh
+```
+
+You can also run both debug + release presets:
+
+```bash
+bash scripts/smoke.sh --both
+```
+
 ---
 
 ## Quick start examples


### PR DESCRIPTION
Adds a short Smoke test section to README documenting the new scripts/smoke.sh harness.\n\nVerification:\n- 
=== Curlee smoke: preset=linux-debug ===
[ok]  cmake configure (linux-debug)
[ok]  cmake build (linux-debug)
[ok]  curlee --help
[ok]  check: requires failure (failed as expected)
[ok]  check: ensures failure (failed as expected)
[ok]  run gated by failed ensures (failed as expected)
[ok]  check: run_success.curlee
[ok]  run: run_success.curlee
[ok]  check: mvp_run_int
[ok]  run: mvp_run_control_flow
[ok]  ctest: curlee_cli_diagnostics_golden_tests
[ok]  smoke suite passed (linux-debug)\n\nCloses #102.