### PR TITLE
docs: add Doxygen comments to public headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  linux-release-artifacts:
+    name: Build linux-release artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build g++ libz3-dev pkg-config clang-format ripgrep
+
+      - name: Configure (linux-release)
+        run: cmake --preset linux-release
+
+      - name: Build (linux-release)
+        run: cmake --build --preset linux-release
+
+      - name: Smoke (linux-release)
+        run: bash scripts/smoke.sh --preset linux-release --skip-build
+
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          arch="$(uname -m)"
+
+          mkdir -p dist
+          cp -v "build/linux-release/curlee" "dist/curlee"
+          chmod +x "dist/curlee"
+
+          tarball="curlee-${tag}-linux-${arch}.tar.gz"
+          tar -C dist -czf "dist/${tarball}" curlee
+
+          (cd dist && sha256sum "${tarball}" curlee > SHA256SUMS.txt)
+
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          tag = os.environ.get("GITHUB_REF_NAME", "(unknown)")
+          sums = Path("dist/SHA256SUMS.txt").read_text(encoding="utf-8")
+
+          notes = f"""# Curlee {tag}
+
+          ## How to verify
+
+          ```bash
+          cmake --preset linux-debug
+          cmake --build --preset linux-debug
+          ctest --preset linux-debug --output-on-failure
+
+          bash scripts/smoke.sh --both
+          ```
+
+          ## Artifacts
+
+          Built from the CMake preset `linux-release` on GitHub Actions (ubuntu-latest).
+
+          ### Checksums (SHA-256)
+
+          ```
+          {sums}
+          ```
+          """
+
+          Path("dist/RELEASE_NOTES.md").write_text(notes, encoding="utf-8")
+          PY
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: dist/RELEASE_NOTES.md
+          files: |
+            dist/curlee
+            dist/*.tar.gz
+            dist/SHA256SUMS.txt
+          fail_on_unmatched_files: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,29 @@ curlee_add_build_info(curlee_cli_check_imported_main_tests)
 
 add_test(NAME curlee_cli_check_imported_main_tests COMMAND curlee_cli_check_imported_main_tests)
 
+add_executable(curlee_cli_check_duplicate_function_tests
+  tests/cli_check_duplicate_function_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_duplicate_function_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_duplicate_function_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_duplicate_function_tests)
+
+add_test(NAME curlee_cli_check_duplicate_function_tests COMMAND curlee_cli_check_duplicate_function_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,29 @@ curlee_add_build_info(curlee_cli_version_tests)
 
 add_test(NAME curlee_cli_version_tests COMMAND curlee_cli_version_tests)
 
+add_executable(curlee_cli_bad_args_tests
+  tests/cli_bad_args_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_bad_args_tests PRIVATE include)
+target_link_libraries(curlee_cli_bad_args_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_bad_args_tests)
+
+add_test(NAME curlee_cli_bad_args_tests COMMAND curlee_cli_bad_args_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,6 +627,29 @@ curlee_add_build_info(curlee_cli_check_import_order_tests)
 
 add_test(NAME curlee_cli_check_import_order_tests COMMAND curlee_cli_check_import_order_tests)
 
+add_executable(curlee_cli_check_import_path_tests
+  tests/cli_check_import_path_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_import_path_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_import_path_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_import_path_tests)
+
+add_test(NAME curlee_cli_check_import_path_tests COMMAND curlee_cli_check_import_path_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,29 @@ curlee_add_build_info(curlee_cli_bad_args_tests)
 
 add_test(NAME curlee_cli_bad_args_tests COMMAND curlee_cli_bad_args_tests)
 
+add_executable(curlee_cli_lex_parse_error_tests
+  tests/cli_lex_parse_error_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_lex_parse_error_tests PRIVATE include)
+target_link_libraries(curlee_cli_lex_parse_error_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_lex_parse_error_tests)
+
+add_test(NAME curlee_cli_lex_parse_error_tests COMMAND curlee_cli_lex_parse_error_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,29 @@ curlee_add_build_info(curlee_cli_check_import_cycle_tests)
 
 add_test(NAME curlee_cli_check_import_cycle_tests COMMAND curlee_cli_check_import_cycle_tests)
 
+add_executable(curlee_cli_check_import_depth_tests
+  tests/cli_check_import_depth_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_import_depth_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_import_depth_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_import_depth_tests)
+
+add_test(NAME curlee_cli_check_import_depth_tests COMMAND curlee_cli_check_import_depth_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,29 @@ curlee_add_build_info(curlee_cli_check_import_error_tests)
 
 add_test(NAME curlee_cli_check_import_error_tests COMMAND curlee_cli_check_import_error_tests)
 
+add_executable(curlee_cli_check_import_cycle_tests
+  tests/cli_check_import_cycle_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_import_cycle_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_import_cycle_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_import_cycle_tests)
+
+add_test(NAME curlee_cli_check_import_cycle_tests COMMAND curlee_cli_check_import_cycle_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,13 @@ target_include_directories(curlee_diag_render_tests PRIVATE include)
 
 add_test(NAME curlee_diag_render_tests COMMAND curlee_diag_render_tests)
 
+add_executable(curlee_header_smoke_tests
+  tests/header_smoke_tests.cpp
+)
+target_include_directories(curlee_header_smoke_tests PRIVATE include)
+
+add_test(NAME curlee_header_smoke_tests COMMAND curlee_header_smoke_tests)
+
 add_executable(curlee_cli_diagnostics_golden_tests
   tests/cli_diagnostics_golden_tests.cpp
   src/bundle/bundle.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,29 @@ curlee_add_build_info(curlee_cli_lex_parse_error_tests)
 
 add_test(NAME curlee_cli_lex_parse_error_tests COMMAND curlee_cli_lex_parse_error_tests)
 
+add_executable(curlee_cli_check_import_error_tests
+  tests/cli_check_import_error_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_import_error_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_import_error_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_import_error_tests)
+
+add_test(NAME curlee_cli_check_import_error_tests COMMAND curlee_cli_check_import_error_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,29 @@ curlee_add_build_info(curlee_cli_check_import_depth_tests)
 
 add_test(NAME curlee_cli_check_import_depth_tests COMMAND curlee_cli_check_import_depth_tests)
 
+add_executable(curlee_cli_check_imported_main_tests
+  tests/cli_check_imported_main_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_imported_main_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_imported_main_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_imported_main_tests)
+
+add_test(NAME curlee_cli_check_imported_main_tests COMMAND curlee_cli_check_imported_main_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,6 +604,29 @@ curlee_add_build_info(curlee_cli_check_duplicate_function_tests)
 
 add_test(NAME curlee_cli_check_duplicate_function_tests COMMAND curlee_cli_check_duplicate_function_tests)
 
+add_executable(curlee_cli_check_import_order_tests
+  tests/cli_check_import_order_tests.cpp
+  src/bundle/bundle.cpp
+  src/cli/cli.cpp
+  src/compiler/emitter.cpp
+  src/diag/render.cpp
+  src/lexer/lexer.cpp
+  src/parser/parser.cpp
+  src/resolver/resolver.cpp
+  src/source/line_map.cpp
+  src/source/source_file.cpp
+  src/types/type_check.cpp
+  src/verification/checker.cpp
+  src/verification/predicate_lowering.cpp
+  src/verification/solver.cpp
+  src/vm/vm.cpp
+)
+target_include_directories(curlee_cli_check_import_order_tests PRIVATE include)
+target_link_libraries(curlee_cli_check_import_order_tests PRIVATE Z3::Z3)
+curlee_add_build_info(curlee_cli_check_import_order_tests)
+
+add_test(NAME curlee_cli_check_import_order_tests COMMAND curlee_cli_check_import_order_tests)
+
 add_test(NAME curlee_cli_bundle_tests COMMAND curlee_cli_bundle_tests)
 
 add_test(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,15 @@ add_test(
   COMMAND curlee_diagnostic_golden_tests ${CMAKE_SOURCE_DIR}/tests/diagnostics
 )
 
+add_executable(curlee_diag_render_tests
+  tests/diag_render_tests.cpp
+  src/diag/render.cpp
+  src/source/line_map.cpp
+)
+target_include_directories(curlee_diag_render_tests PRIVATE include)
+
+add_test(NAME curlee_diag_render_tests COMMAND curlee_diag_render_tests)
+
 add_executable(curlee_cli_diagnostics_golden_tests
   tests/cli_diagnostics_golden_tests.cpp
   src/bundle/bundle.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,14 @@ target_include_directories(curlee_line_map_tests PRIVATE include)
 
 add_test(NAME curlee_line_map_tests COMMAND curlee_line_map_tests)
 
+add_executable(curlee_source_file_tests
+  tests/source_file_tests.cpp
+  src/source/source_file.cpp
+)
+target_include_directories(curlee_source_file_tests PRIVATE include)
+
+add_test(NAME curlee_source_file_tests COMMAND curlee_source_file_tests)
+
 add_executable(curlee_diagnostic_golden_tests
   tests/diagnostic_golden_tests.cpp
   src/diag/render.cpp

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,6 +23,25 @@
             }
         },
         {
+            "name": "linux-debug-coverage",
+            "displayName": "Linux Debug (Coverage)",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/linux-debug-coverage",
+            "installDir": "${sourceDir}/build/linux-debug-coverage/install",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_CXX_FLAGS": "-O0 -g --coverage",
+                "CMAKE_EXE_LINKER_FLAGS": "--coverage",
+                "CMAKE_SHARED_LINKER_FLAGS": "--coverage"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
             "name": "linux-release",
             "displayName": "Linux Release",
             "generator": "Ninja",
@@ -45,6 +64,10 @@
             "configurePreset": "linux-debug"
         },
         {
+            "name": "linux-debug-coverage",
+            "configurePreset": "linux-debug-coverage"
+        },
+        {
             "name": "linux-release",
             "configurePreset": "linux-release"
         }
@@ -53,6 +76,10 @@
         {
             "name": "linux-debug",
             "configurePreset": "linux-debug"
+        },
+        {
+            "name": "linux-debug-coverage",
+            "configurePreset": "linux-debug-coverage"
         },
         {
             "name": "linux-release",

--- a/README.md
+++ b/README.md
@@ -186,6 +186,36 @@ You can also run both debug + release presets:
 bash scripts/smoke.sh --both
 ```
 
+### Coverage (unit tests)
+
+To generate a coverage report from unit tests, Curlee provides a coverage preset + helper script.
+
+Dependencies (Ubuntu/Debian):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y gcovr
+```
+
+Run:
+
+```bash
+bash scripts/coverage.sh
+```
+
+This will:
+
+- Configure/build/test with the `linux-debug-coverage` preset.
+- Generate an HTML report at `build/coverage/coverage.html`.
+- Fail the run if line coverage is below the threshold (default: 100%).
+
+Adjust threshold or disable failing:
+
+```bash
+bash scripts/coverage.sh --fail-under 95
+bash scripts/coverage.sh --no-fail
+```
+
 ---
 
 ## Quick start examples

--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ This will:
 - Generate an HTML report at `build/coverage/coverage.html`.
 - Fail the run if line coverage is below the threshold (default: 100%).
 
+Note: the gcovr report excludes `throw` and unreachable branches by default (so branch coverage isn't dominated by exception edges). You can opt back in with:
+
+```bash
+bash scripts/coverage.sh --include-throw-branches
+bash scripts/coverage.sh --include-unreachable-branches
+```
+
 Adjust threshold or disable failing:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -236,4 +236,14 @@ MIT. See LICENSE.
 - Keep changes small and test-driven.
 - Prefer golden tests for diagnostics and verification failures.
 
+### GitHub CLI: `gh pr edit` workaround
+
+In this repo, `gh pr edit` may fail due to a GraphQL error involving deprecated classic project cards.
+
+Workaround: patch the PR body via the REST API using:
+
+```bash
+scripts/gh_pr_patch_body.sh <pr-number> <body-file>
+```
+
 For agent guidance, see [.github/copilot-instructions.md](.github/copilot-instructions.md).

--- a/include/curlee/bundle/bundle.h
+++ b/include/curlee/bundle/bundle.h
@@ -6,17 +6,24 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file bundle.h
+ * @brief Bundle format helpers for packaging bytecode, manifest and imports.
+ */
+
 namespace curlee::bundle
 {
 
 inline constexpr int kBundleFormatVersion = 1;
 
+/** @brief A pinned import with its content hash. */
 struct ImportPin
 {
     std::string path;
     std::string hash;
 };
 
+/** @brief Bundle manifest containing metadata and pins. */
 struct Manifest
 {
     int format_version = kBundleFormatVersion;
@@ -26,12 +33,14 @@ struct Manifest
     std::optional<std::string> proof;
 };
 
+/** @brief Full bundle containing manifest and bytecode. */
 struct Bundle
 {
     Manifest manifest;
     std::vector<std::uint8_t> bytecode;
 };
 
+/** @brief Error returned when bundle IO/parsing fails. */
 struct BundleError
 {
     std::string message;
@@ -39,6 +48,7 @@ struct BundleError
 
 using BundleResult = std::variant<Bundle, BundleError>;
 
+/** @brief Compute a stable hash of bytes for manifest fingerprinting. */
 [[nodiscard]] std::string hash_bytes(const std::vector<std::uint8_t>& bytes);
 
 [[nodiscard]] BundleResult read_bundle(const std::string& path);

--- a/include/curlee/cli/cli.h
+++ b/include/curlee/cli/cli.h
@@ -1,9 +1,14 @@
 #pragma once
 
+/**
+ * @file cli.h
+ * @brief Command-line entry point for the curlee binary.
+ */
+
 namespace curlee::cli
 {
 
-// Returns process exit code.
+/** @brief Run the CLI using argc/argv; returns process exit code. */
 int run(int argc, char** argv);
 
 } // namespace curlee::cli

--- a/include/curlee/compiler/emitter.h
+++ b/include/curlee/compiler/emitter.h
@@ -6,11 +6,18 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file emitter.h
+ * @brief Bytecode emission API from the compiler's AST.
+ */
+
 namespace curlee::compiler
 {
 
+/** @brief Result of emitting bytecode: a Chunk or diagnostics. */
 using EmitResult = std::variant<curlee::vm::Chunk, std::vector<curlee::diag::Diagnostic>>;
 
+/** @brief Emit VM bytecode for the provided Program or return diagnostics. */
 [[nodiscard]] EmitResult emit_bytecode(const curlee::parser::Program& program);
 
 } // namespace curlee::compiler

--- a/include/curlee/compiler/tensor_backend.h
+++ b/include/curlee/compiler/tensor_backend.h
@@ -6,9 +6,15 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file tensor_backend.h
+ * @brief Execution backend API for the tensor IR used in tests.
+ */
+
 namespace curlee::compiler::tensor_ir
 {
 
+/** @brief Execution error returned by backends. */
 struct ExecError
 {
     std::string message;
@@ -16,6 +22,7 @@ struct ExecError
 
 template <typename T> using Result = std::variant<T, ExecError>;
 
+/** @brief A concrete tensor instance produced by a backend. */
 struct Tensor
 {
     DType dtype;
@@ -23,6 +30,7 @@ struct Tensor
     std::vector<std::int32_t> i32;
 };
 
+/** @brief Abstract execution backend interface. */
 class Backend
 {
   public:
@@ -32,8 +40,10 @@ class Backend
     virtual Result<Tensor> add(const Tensor& lhs, const Tensor& rhs) = 0;
 };
 
+/** @brief Execute the program and return the tensor value for `output` using `backend`. */
 Result<Tensor> execute(const Program& program, ValueId output, Backend& backend);
 
+/** @brief Reference CPU backend implementation for tests. */
 class CpuBackend final : public Backend
 {
   public:

--- a/include/curlee/compiler/tensor_ir.h
+++ b/include/curlee/compiler/tensor_ir.h
@@ -4,24 +4,33 @@
 #include <string>
 #include <vector>
 
+/**
+ * @file tensor_ir.h
+ * @brief Minimal IR for tensor computation used by compiler tests.
+ */
+
 namespace curlee::compiler::tensor_ir
 {
 
+/** @brief Element dtype for tensors (MVP: only I32 supported). */
 enum class DType
 {
     I32,
 };
 
+/** @brief Shape descriptor for tensors. */
 struct Shape
 {
     std::vector<std::int64_t> dims;
 };
 
+/** @brief Opaque handle to a value produced within a Program. */
 struct ValueId
 {
     std::uint32_t id;
 };
 
+/** @brief A simple tensor program builder. */
 class Program
 {
   public:

--- a/include/curlee/diag/diagnostic.h
+++ b/include/curlee/diag/diagnostic.h
@@ -5,9 +5,15 @@
 #include <string>
 #include <vector>
 
+/**
+ * @file diagnostic.h
+ * @brief Types for diagnostics (errors, warnings and notes) produced by the compiler.
+ */
+
 namespace curlee::diag
 {
 
+/** @brief Severity level for a diagnostic. */
 enum class Severity
 {
     Error,
@@ -15,12 +21,18 @@ enum class Severity
     Note,
 };
 
+/** @brief Additional related message attached to a diagnostic, with optional span. */
 struct Related
 {
     std::string message;
     std::optional<curlee::source::Span> span;
 };
 
+/**
+ * @brief A diagnostic message with optional source span and related notes.
+ *
+ * Diagnostics are used throughout the toolchain to report errors and warnings.
+ */
 struct Diagnostic
 {
     Severity severity = Severity::Error;

--- a/include/curlee/interop/python_ffi.h
+++ b/include/curlee/interop/python_ffi.h
@@ -6,16 +6,28 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file python_ffi.h
+ * @brief Small host-bound Python FFI helper (test harness only).
+ */
+
 namespace curlee::interop
 {
 
+/** @brief Error returned when a Python call fails. */
 struct PythonFfiError
 {
     std::string message;
 };
 
+/** @brief Result of `call_python`: empty on success or an error. */
 using PythonFfiResult = std::variant<std::monostate, PythonFfiError>;
 
+/**
+ * @brief Call a Python function in `module::function` with string args.
+ *
+ * Requires the provided capabilities to allow Python calls.
+ */
 [[nodiscard]] PythonFfiResult call_python(const curlee::runtime::Capabilities& capabilities,
                                           std::string_view module, std::string_view function,
                                           const std::vector<std::string>& args);

--- a/include/curlee/lexer/lexer.h
+++ b/include/curlee/lexer/lexer.h
@@ -6,12 +6,18 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file lexer.h
+ * @brief Public lexer API: tokenizes input into Token sequences or a diagnostic.
+ */
+
 namespace curlee::lexer
 {
 
+/** @brief Result of lexing: token vector on success, diagnostic on failure. */
 using LexResult = std::variant<std::vector<Token>, curlee::diag::Diagnostic>;
 
-// Lexes the full input into tokens. On success includes a terminal Eof token.
+/** @brief Lex the provided input into tokens. On success includes a terminal Eof token. */
 [[nodiscard]] LexResult lex(std::string_view input);
 
 } // namespace curlee::lexer

--- a/include/curlee/lexer/token.h
+++ b/include/curlee/lexer/token.h
@@ -3,9 +3,15 @@
 #include <curlee/source/span.h>
 #include <string_view>
 
+/**
+ * @file token.h
+ * @brief Token kinds and token representation produced by the lexer.
+ */
+
 namespace curlee::lexer
 {
 
+/** @brief Kinds of tokens recognized by the lexer. */
 enum class TokenKind
 {
     Eof,
@@ -71,6 +77,7 @@ enum class TokenKind
     OrOr,
 };
 
+/** @brief Representation of a token with kind, lexeme and source span. */
 struct Token
 {
     TokenKind kind = TokenKind::Eof;
@@ -78,6 +85,7 @@ struct Token
     curlee::source::Span span;
 };
 
+/** @brief Stringify a TokenKind for diagnostics and tests. */
 [[nodiscard]] constexpr std::string_view to_string(TokenKind kind)
 {
     switch (kind)

--- a/include/curlee/parser/ast.h
+++ b/include/curlee/parser/ast.h
@@ -11,38 +11,50 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file ast.h
+ * @brief Abstract syntax tree (AST) node types produced by the parser.
+ */
+
 namespace curlee::parser
 {
 
+/** @brief A (possibly qualified) type name with its source span. */
 struct TypeName
 {
     curlee::source::Span span;
     std::string_view name;
 };
 
+/** Forward declaration for predicate nodes. */
 struct Pred;
 
+/** @brief Integer literal predicate (lexeme preserved). */
 struct PredInt
 {
     std::string_view lexeme;
 };
 
+/** @brief Boolean literal predicate. */
 struct PredBool
 {
     bool value = false;
 };
 
+/** @brief Named predicate (identifier). */
 struct PredName
 {
     std::string_view name;
 };
 
+/** @brief Unary predicate (e.g. `!p`). */
 struct PredUnary
 {
     curlee::lexer::TokenKind op;
     std::unique_ptr<Pred> rhs;
 };
 
+/** @brief Binary predicate (e.g. `a == b`). */
 struct PredBinary
 {
     curlee::lexer::TokenKind op;
@@ -50,57 +62,70 @@ struct PredBinary
     std::unique_ptr<Pred> rhs;
 };
 
+/** @brief Parenthesized predicate. */
 struct PredGroup
 {
     std::unique_ptr<Pred> inner;
 };
 
+/**
+ * @brief A predicate node with source span and concrete variant.
+ */
 struct Pred
 {
     curlee::source::Span span;
     std::variant<PredInt, PredBool, PredName, PredUnary, PredBinary, PredGroup> node;
 };
 
+/** Forward declaration for expression nodes. */
 struct Expr;
 
+/** @brief Integer literal expression. */
 struct IntExpr
 {
     std::string_view lexeme;
 };
 
+/** @brief Boolean literal expression. */
 struct BoolExpr
 {
     bool value = false;
 };
 
+/** @brief String literal expression (lexeme includes quotes). */
 struct StringExpr
 {
     std::string_view lexeme; // includes quotes, preserves escapes
 };
 
+/** @brief Simple name expression (identifier). */
 struct NameExpr
 {
     std::string_view name;
 };
 
+/** @brief Scoped name expression (e.g. module::name). */
 struct ScopedNameExpr
 {
     std::string_view lhs;
     std::string_view rhs;
 };
 
+/** @brief Member access expression (base.member). */
 struct MemberExpr
 {
     std::unique_ptr<Expr> base;
     std::string_view member;
 };
 
+/** @brief Unary expression (e.g. `-x`). */
 struct UnaryExpr
 {
     curlee::lexer::TokenKind op;
     std::unique_ptr<Expr> rhs;
 };
 
+/** @brief Binary expression (e.g. `a + b`). */
 struct BinaryExpr
 {
     curlee::lexer::TokenKind op;
@@ -108,12 +133,14 @@ struct BinaryExpr
     std::unique_ptr<Expr> rhs;
 };
 
+/** @brief Function call expression. */
 struct CallExpr
 {
     std::unique_ptr<Expr> callee;
     std::vector<Expr> args;
 };
 
+/** @brief Field in a struct literal with source span. */
 struct StructLiteralExprField
 {
     curlee::source::Span span;
@@ -121,17 +148,22 @@ struct StructLiteralExprField
     std::unique_ptr<Expr> value;
 };
 
+/** @brief Struct literal expression (e.g. `T { a: 1 }`). */
 struct StructLiteralExpr
 {
     std::string_view type_name;
     std::vector<StructLiteralExprField> fields;
 };
 
+/** @brief Parenthesized or grouped expression. */
 struct GroupExpr
 {
     std::unique_ptr<Expr> inner;
 };
 
+/**
+ * @brief A general expression node with id, span and variant payload.
+ */
 struct Expr
 {
     std::size_t id = 0;
@@ -141,6 +173,7 @@ struct Expr
         node;
 };
 
+/** @brief Let statement (local binding). */
 struct LetStmt
 {
     std::string_view name;
@@ -149,18 +182,22 @@ struct LetStmt
     Expr value;
 };
 
+/** @brief Return statement (optional return value). */
 struct ReturnStmt
 {
     std::optional<Expr> value;
 };
 
+/** @brief Expression statement. */
 struct ExprStmt
 {
     Expr expr;
 };
 
+/** Forward declaration for block nodes. */
 struct Block;
 
+/** @brief If statement with optional else block. */
 struct IfStmt
 {
     Expr cond;
@@ -168,34 +205,44 @@ struct IfStmt
     std::unique_ptr<Block> else_block;
 };
 
+/** @brief While loop statement. */
 struct WhileStmt
 {
     Expr cond;
     std::unique_ptr<Block> body;
 };
 
+/** @brief Unsafe block statement (MVP semantics for capabilities). */
 struct UnsafeStmt
 {
     std::unique_ptr<Block> body;
 };
 
+/** @brief Block statement wrapper. */
 struct BlockStmt
 {
     std::unique_ptr<Block> block;
 };
 
+/**
+ * @brief General statement node with span and variant payload.
+ */
 struct Stmt
 {
     curlee::source::Span span;
     std::variant<LetStmt, ReturnStmt, ExprStmt, BlockStmt, IfStmt, WhileStmt, UnsafeStmt> node;
 };
 
+/** @brief A sequence of statements with a source span. */
 struct Block
 {
     curlee::source::Span span;
     std::vector<Stmt> stmts;
 };
 
+/**
+ * @brief Top-level function definition with parameters, body and contracts.
+ */
 struct Function
 {
     curlee::source::Span span;
@@ -218,6 +265,7 @@ struct Function
     std::optional<TypeName> return_type;
 };
 
+/** @brief Import declaration (module path and optional alias). */
 struct ImportDecl
 {
     curlee::source::Span span;
@@ -225,6 +273,7 @@ struct ImportDecl
     std::optional<std::string_view> alias;
 };
 
+/** @brief Field declaration inside a struct. */
 struct StructDeclField
 {
     curlee::source::Span span;
@@ -232,6 +281,7 @@ struct StructDeclField
     TypeName type;
 };
 
+/** @brief Struct declaration with fields. */
 struct StructDecl
 {
     curlee::source::Span span;
@@ -239,6 +289,7 @@ struct StructDecl
     std::vector<StructDeclField> fields;
 };
 
+/** @brief Variant of an enum type, optionally carrying a payload type. */
 struct EnumDeclVariant
 {
     curlee::source::Span span;
@@ -246,6 +297,7 @@ struct EnumDeclVariant
     std::optional<TypeName> payload;
 };
 
+/** @brief Enum declaration with named variants. */
 struct EnumDecl
 {
     curlee::source::Span span;
@@ -253,6 +305,7 @@ struct EnumDecl
     std::vector<EnumDeclVariant> variants;
 };
 
+/** @brief Full parsed program (imports, types and functions). */
 struct Program
 {
     std::vector<ImportDecl> imports;

--- a/include/curlee/parser/parser.h
+++ b/include/curlee/parser/parser.h
@@ -8,16 +8,27 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file parser.h
+ * @brief Public parser API returning parse results or diagnostics.
+ */
+
 namespace curlee::parser
 {
 
+/** @brief Result of parsing: either a Program or diagnostics. */
 using ParseResult = std::variant<Program, std::vector<curlee::diag::Diagnostic>>;
 
+/** @brief Parse a sequence of tokens into a Program or diagnostics. */
 [[nodiscard]] ParseResult parse(std::span<const curlee::lexer::Token> tokens);
+/** @brief Dump a Program to a human-readable string (for debugging/tests). */
 [[nodiscard]] std::string dump(const Program& program);
 
-// Recomputes expression IDs so they are unique across the full program.
-// Useful after program transformations (e.g., merging imported modules).
+/**
+ * @brief Reassign expression ids so they are unique across the program.
+ *
+ * Useful after transformations that merge or reorder expressions.
+ */
 void reassign_expr_ids(Program& program);
 
 } // namespace curlee::parser

--- a/include/curlee/resolver/resolver.h
+++ b/include/curlee/resolver/resolver.h
@@ -10,9 +10,15 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file resolver.h
+ * @brief Name resolution API and result types.
+ */
+
 namespace curlee::resolver
 {
 
+/** @brief A resolved symbol with its id, name and declaration span. */
 struct Symbol
 {
     SymbolId id;
@@ -20,12 +26,14 @@ struct Symbol
     curlee::source::Span span;
 };
 
+/** @brief A use of a name referring to a target symbol, with its span. */
 struct NameUse
 {
     SymbolId target;
     curlee::source::Span span;
 };
 
+/** @brief Resolution result containing symbol table and uses mapping. */
 struct Resolution
 {
     std::vector<Symbol> symbols;
@@ -34,9 +42,12 @@ struct Resolution
 
 using ResolveResult = std::variant<Resolution, std::vector<curlee::diag::Diagnostic>>;
 
+/** @brief Resolve names in `program`. */
 [[nodiscard]] ResolveResult resolve(const curlee::parser::Program& program);
+/** @brief Resolve names with an associated source file (for precise spans). */
 [[nodiscard]] ResolveResult resolve(const curlee::parser::Program& program,
                                     const curlee::source::SourceFile& source);
+/** @brief Resolve with an optional entry directory to resolve import paths. */
 [[nodiscard]] ResolveResult resolve(const curlee::parser::Program& program,
                                     const curlee::source::SourceFile& source,
                                     std::optional<std::filesystem::path> entry_dir);

--- a/include/curlee/resolver/symbol.h
+++ b/include/curlee/resolver/symbol.h
@@ -2,9 +2,15 @@
 
 #include <cstdint>
 
+/**
+ * @file symbol.h
+ * @brief Symbol identifier used by the resolver.
+ */
+
 namespace curlee::resolver
 {
 
+/** @brief Opaque numeric id for a resolved symbol. */
 struct SymbolId
 {
     std::uint32_t value = 0;

--- a/include/curlee/runtime/capabilities.h
+++ b/include/curlee/runtime/capabilities.h
@@ -3,11 +3,19 @@
 #include <string>
 #include <unordered_set>
 
+/**
+ * @file capabilities.h
+ * @brief Host-supplied capability set used to gate unsafe or host interactions.
+ */
+
 namespace curlee::runtime
 {
 
-// Capabilities are explicit, opt-in permissions granted by the host (e.g. CLI).
-// By default, no capabilities are granted.
+/**
+ * @brief Capabilities are explicit, opt-in permissions granted by the host (e.g. CLI).
+ *
+ * By default, no capabilities are granted.
+ */
 using Capabilities = std::unordered_set<std::string>;
 
 } // namespace curlee::runtime

--- a/include/curlee/source/line_map.h
+++ b/include/curlee/source/line_map.h
@@ -4,22 +4,38 @@
 #include <string_view>
 #include <vector>
 
+/**
+ * @file line_map.h
+ * @brief Utilities to map byte offsets to line/column positions within source text.
+ */
+
 namespace curlee::source
 {
 
+/**
+ * @brief A 1-based line/column pair.
+ *
+ * Both fields are 1-based; columns are counted in bytes for the MVP.
+ */
 struct LineCol
 {
     std::size_t line = 1; // 1-based
     std::size_t col = 1;  // 1-based, in bytes for MVP
 };
 
+/**
+ * @brief Precomputes line start offsets for fast offset-to-line/col queries.
+ */
 class LineMap
 {
   public:
     explicit LineMap(std::string_view text);
 
+    /** @brief Convert a byte offset into a LineCol (1-based). */
     [[nodiscard]] LineCol offset_to_line_col(std::size_t offset) const;
+    /** @brief Return the start offset (byte index) of the given 1-based line. */
     [[nodiscard]] std::size_t line_start_offset(std::size_t line) const;
+    /** @brief Return the total number of lines in the mapped text. */
     [[nodiscard]] std::size_t line_count() const;
 
   private:

--- a/include/curlee/source/source_file.h
+++ b/include/curlee/source/source_file.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <istream>
 #include <string>
 #include <variant>
 
@@ -20,5 +21,7 @@ struct LoadError
 using LoadResult = std::variant<SourceFile, LoadError>;
 
 LoadResult load_source_file(const std::string& path);
+
+LoadResult load_source_stream(std::istream& in, const std::string& path);
 
 } // namespace curlee::source

--- a/include/curlee/source/source_file.h
+++ b/include/curlee/source/source_file.h
@@ -4,15 +4,22 @@
 #include <string>
 #include <variant>
 
+/**
+ * @file source_file.h
+ * @brief Loading utilities for source files and streams.
+ */
+
 namespace curlee::source
 {
 
+/** @brief Represents the contents of a source file on disk. */
 struct SourceFile
 {
-    std::string path;
-    std::string contents;
+    std::string path;     /**< File path (as provided to the loader). */
+    std::string contents; /**< Raw file contents. */
 };
 
+/** @brief Error returned when a source cannot be loaded. */
 struct LoadError
 {
     std::string message;
@@ -20,8 +27,10 @@ struct LoadError
 
 using LoadResult = std::variant<SourceFile, LoadError>;
 
+/** @brief Load the file at `path` into a SourceFile or return a LoadError. */
 LoadResult load_source_file(const std::string& path);
 
+/** @brief Load source from the provided input stream; `path` is used for diagnostics. */
 LoadResult load_source_stream(std::istream& in, const std::string& path);
 
 } // namespace curlee::source

--- a/include/curlee/source/span.h
+++ b/include/curlee/source/span.h
@@ -2,14 +2,25 @@
 
 #include <cstddef>
 
+/**
+ * @file span.h
+ * @brief Small utilities for byte-span locations within source text.
+ */
+
 namespace curlee::source
 {
 
+/**
+ * @brief Represents a byte-range within a source file.
+ *
+ * Offsets are byte-based and [start, end) where start is inclusive and end is exclusive.
+ */
 struct Span
 {
     std::size_t start = 0; // inclusive byte offset
     std::size_t end = 0;   // exclusive byte offset
 
+    /** @brief Returns the length (in bytes) of the span. */
     [[nodiscard]] constexpr std::size_t length() const { return end - start; }
 };
 

--- a/include/curlee/types/type.h
+++ b/include/curlee/types/type.h
@@ -5,9 +5,15 @@
 #include <string_view>
 #include <vector>
 
+/**
+ * @file type.h
+ * @brief Basic type representations used by the resolver and verifier.
+ */
+
 namespace curlee::types
 {
 
+/** @brief Kind of a type (primitive or nominal). */
 enum class TypeKind
 {
     Int,
@@ -18,6 +24,11 @@ enum class TypeKind
     Enum,
 };
 
+/**
+ * @brief A lightweight type descriptor.
+ *
+ * For nominal types (Struct/Enum) the `name` field stores the declared type name.
+ */
 struct Type
 {
     TypeKind kind;
@@ -39,6 +50,7 @@ struct Type
     return true;
 }
 
+/** @brief Function type with parameter types and a result type. */
 struct FunctionType
 {
     std::vector<Type> params;
@@ -50,6 +62,7 @@ struct FunctionType
     return a.params == b.params && a.result == b.result;
 }
 
+/** @brief Opaque capability type (identified by name). */
 struct CapabilityType
 {
     // Opaque capability-bearing values: equality is name-based.
@@ -61,6 +74,7 @@ struct CapabilityType
     return a.name == b.name;
 }
 
+/** @brief Stringify a TypeKind for diagnostics and tests. */
 [[nodiscard]] constexpr std::string_view to_string(TypeKind kind)
 {
     switch (kind)
@@ -90,6 +104,7 @@ struct CapabilityType
     return to_string(t.kind);
 }
 
+/** @brief Resolve a core type name ("Int", "Bool", "String", "Unit") to a Type. */
 [[nodiscard]] inline std::optional<Type> core_type_from_name(std::string_view name)
 {
     if (name == "Int")

--- a/include/curlee/types/type_check.h
+++ b/include/curlee/types/type_check.h
@@ -14,9 +14,15 @@ struct Expr;
 struct Program;
 } // namespace curlee::parser
 
+/**
+ * @file type_check.h
+ * @brief Type checking API and result types.
+ */
+
 namespace curlee::types
 {
 
+/** @brief Type information mapping expression ids to inferred types. */
 struct TypeInfo
 {
     std::unordered_map<std::size_t, Type> expr_types;
@@ -32,8 +38,10 @@ struct TypeInfo
     }
 };
 
+/** @brief Result of running type checking: either TypeInfo or a list of diagnostics. */
 using TypeCheckResult = std::variant<TypeInfo, std::vector<curlee::diag::Diagnostic>>;
 
+/** @brief Run type checking on the program, returning types or diagnostics. */
 [[nodiscard]] TypeCheckResult type_check(const curlee::parser::Program& program);
 
 } // namespace curlee::types

--- a/include/curlee/verification/checker.h
+++ b/include/curlee/verification/checker.h
@@ -6,15 +6,23 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @file checker.h
+ * @brief Public API for program verification.
+ */
+
 namespace curlee::verification
 {
 
+/** @brief Marker type indicating verification succeeded. */
 struct Verified
 {
 };
 
+/** @brief Result of verification: success marker or diagnostics. */
 using VerificationResult = std::variant<Verified, std::vector<curlee::diag::Diagnostic>>;
 
+/** @brief Verify the program using provided type information; returns diagnostics on failure. */
 [[nodiscard]] VerificationResult verify(const curlee::parser::Program& program,
                                         const curlee::types::TypeInfo& type_info);
 

--- a/include/curlee/verification/predicate_lowering.h
+++ b/include/curlee/verification/predicate_lowering.h
@@ -9,9 +9,19 @@
 #include <vector>
 #include <z3++.h>
 
+/**
+ * @file predicate_lowering.h
+ * @brief Lower parser predicates into Z3 expressions for verification.
+ */
+
 namespace curlee::verification
 {
 
+/**
+ * @brief Context used when lowering predicates to Z3 expressions.
+ *
+ * Holds temporary results and symbol maps for int and bool variables.
+ */
 struct LoweringContext
 {
     explicit LoweringContext(z3::context& context) : ctx(context) {}
@@ -23,8 +33,10 @@ struct LoweringContext
     std::unordered_map<std::string_view, z3::expr> bool_vars;
 };
 
+/** @brief Result of lowering: either a z3::expr or a diagnostic on error. */
 using LoweringResult = std::variant<z3::expr, curlee::diag::Diagnostic>;
 
+/** @brief Lower a parsed predicate into a Z3 expression using the given context. */
 [[nodiscard]] LoweringResult lower_predicate(const curlee::parser::Pred& pred,
                                              const LoweringContext& ctx);
 

--- a/include/curlee/verification/solver.h
+++ b/include/curlee/verification/solver.h
@@ -5,9 +5,15 @@
 #include <vector>
 #include <z3++.h>
 
+/**
+ * @file solver.h
+ * @brief Thin wrapper around Z3 used by the verification subsystem.
+ */
+
 namespace curlee::verification
 {
 
+/** @brief Check result from the solver. */
 enum class CheckResult
 {
     Sat,
@@ -15,17 +21,20 @@ enum class CheckResult
     Unknown,
 };
 
+/** @brief Single entry of a model (variable name and value as string). */
 struct ModelEntry
 {
     std::string name;
     std::string value;
 };
 
+/** @brief Model returned by the solver, as a collection of entries. */
 struct Model
 {
     std::vector<ModelEntry> entries;
 };
 
+/** @brief Solver wrapper exposing a minimal API used by the verifier. */
 class Solver
 {
   public:

--- a/include/curlee/vm/bytecode.h
+++ b/include/curlee/vm/bytecode.h
@@ -6,9 +6,15 @@
 #include <curlee/vm/value.h>
 #include <vector>
 
+/**
+ * @file bytecode.h
+ * @brief VM instruction encodings and chunk container.
+ */
+
 namespace curlee::vm
 {
 
+/** @brief Bytecode opcodes executed by the VM. */
 enum class OpCode : std::uint8_t
 {
     Constant,
@@ -36,6 +42,7 @@ enum class OpCode : std::uint8_t
     PythonCall,
 };
 
+/** @brief A compiled chunk of bytecode, constants and span map. */
 struct Chunk
 {
     std::vector<std::uint8_t> code;

--- a/include/curlee/vm/value.h
+++ b/include/curlee/vm/value.h
@@ -3,9 +3,15 @@
 #include <cstdint>
 #include <string>
 
+/**
+ * @file value.h
+ * @brief Runtime value representation used by the VM for evaluation and tests.
+ */
+
 namespace curlee::vm
 {
 
+/** @brief Kind of a runtime value. */
 enum class ValueKind
 {
     Int,
@@ -14,6 +20,11 @@ enum class ValueKind
     Unit,
 };
 
+/**
+ * @brief A simple value container used by the VM.
+ *
+ * Uses explicit fields for each variant for simplicity and testing convenience.
+ */
 struct Value
 {
     ValueKind kind = ValueKind::Unit;
@@ -45,6 +56,7 @@ struct Value
     static Value unit_v() { return Value{}; }
 };
 
+/** @brief Equality comparison for values. */
 inline bool operator==(const Value& a, const Value& b)
 {
     if (a.kind != b.kind)
@@ -65,6 +77,7 @@ inline bool operator==(const Value& a, const Value& b)
     return false;
 }
 
+/** @brief Convert a runtime Value to a human-readable string. */
 inline std::string to_string(const Value& v)
 {
     switch (v.kind)

--- a/include/curlee/vm/vm.h
+++ b/include/curlee/vm/vm.h
@@ -7,9 +7,15 @@
 #include <optional>
 #include <string>
 
+/**
+ * @file vm.h
+ * @brief VM entrypoints and runtime execution helpers.
+ */
+
 namespace curlee::vm
 {
 
+/** @brief Result of executing a chunk in the VM. */
 struct VmResult
 {
     bool ok = true;
@@ -18,15 +24,22 @@ struct VmResult
     std::optional<curlee::source::Span> error_span;
 };
 
+/**
+ * @brief Simple deterministic virtual machine used by the test harness and runtime.
+ */
 class VM
 {
   public:
     using Capabilities = curlee::runtime::Capabilities;
 
+    /** @brief Run a chunk to completion using default fuel and capabilities. */
     [[nodiscard]] VmResult run(const Chunk& chunk);
+    /** @brief Run a chunk with a fuel limit (to bound execution). */
     [[nodiscard]] VmResult run(const Chunk& chunk, std::size_t fuel);
 
+    /** @brief Run with explicit capabilities. */
     [[nodiscard]] VmResult run(const Chunk& chunk, const Capabilities& capabilities);
+    /** @brief Run with fuel and explicit capabilities. */
     [[nodiscard]] VmResult run(const Chunk& chunk, std::size_t fuel,
                                const Capabilities& capabilities);
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 preset="linux-debug-coverage"
 fail_under="100"
 out_dir="build/coverage"
+exclude_throw_branches=1
+exclude_unreachable_branches=1
 
 usage() {
   cat <<'EOF'
 Usage: scripts/coverage.sh [--preset <cmake-preset>] [--out <dir>] [--fail-under <percent>] [--no-fail]
+                           [--include-throw-branches] [--include-unreachable-branches]
 
 Builds + runs tests under coverage instrumentation, then prints a coverage summary.
 
@@ -24,6 +27,7 @@ Examples:
   bash scripts/coverage.sh
   bash scripts/coverage.sh --fail-under 95
   bash scripts/coverage.sh --no-fail
+  bash scripts/coverage.sh --include-throw-branches
 EOF
 }
 
@@ -39,6 +43,10 @@ while [[ $# -gt 0 ]]; do
       fail_under="$2"; shift 2 ;;
     --no-fail)
       no_fail=1; shift ;;
+    --include-throw-branches)
+      exclude_throw_branches=0; shift ;;
+    --include-unreachable-branches)
+      exclude_unreachable_branches=0; shift ;;
     -h|--help)
       usage; exit 0 ;;
     *)
@@ -87,6 +95,14 @@ if command -v gcovr >/dev/null 2>&1; then
     --output "$out_dir/coverage.txt"
     --html-details "$out_dir/coverage.html"
   )
+
+  if [[ $exclude_throw_branches -eq 1 ]]; then
+    args+=(--exclude-throw-branches)
+  fi
+
+  if [[ $exclude_unreachable_branches -eq 1 ]]; then
+    args+=(--exclude-unreachable-branches)
+  fi
 
   if [[ $no_fail -eq 0 ]]; then
     args+=(--fail-under-line "$fail_under")

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+preset="linux-debug-coverage"
+fail_under="100"
+out_dir="build/coverage"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/coverage.sh [--preset <cmake-preset>] [--out <dir>] [--fail-under <percent>] [--no-fail]
+
+Builds + runs tests under coverage instrumentation, then prints a coverage summary.
+
+Defaults:
+  --preset      linux-debug-coverage
+  --out         build/coverage
+  --fail-under  100
+
+Requires one of:
+  - gcovr (recommended), or
+  - lcov + genhtml
+
+Examples:
+  bash scripts/coverage.sh
+  bash scripts/coverage.sh --fail-under 95
+  bash scripts/coverage.sh --no-fail
+EOF
+}
+
+no_fail=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --preset)
+      preset="$2"; shift 2 ;;
+    --out)
+      out_dir="$2"; shift 2 ;;
+    --fail-under)
+      fail_under="$2"; shift 2 ;;
+    --no-fail)
+      no_fail=1; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cmake --preset "$preset"
+cmake --build --preset "$preset"
+ctest --preset "$preset" --output-on-failure
+
+mkdir -p "$out_dir"
+
+# Try gcovr first.
+if command -v gcovr >/dev/null 2>&1; then
+  # Clean previous reports (but keep directory).
+  rm -f "$out_dir"/coverage.* || true
+
+  # Notes:
+  # - root = repo root
+  # - object-directory = preset build dir
+  # - exclude build/ and any third_party-style dirs (none currently)
+  build_dir="$repo_root/build/${preset}"
+
+  # CMake compiler-id objects can emit .gcno/.gcda files that don't map back to
+  # stable sources, which causes noisy gcovr warnings/errors.
+  find "$build_dir/CMakeFiles" -path '*/CompilerIdCXX/*' \( -name '*.gcno' -o -name '*.gcda' \) -delete 2>/dev/null || true
+
+  args=(
+    --root "$repo_root"
+    --object-directory "$build_dir"
+    # Exclude build artifacts (including CMake compiler-id objects that gcovr can
+    # fail to resolve back to sources).
+    --exclude ".*${repo_root}/build/.*"
+    --exclude ".*${build_dir}/CMakeFiles/.*"
+    --gcov-ignore-errors no_working_dir_found
+    --print-summary
+    --txt
+    --txt-metric branch
+    --output "$out_dir/coverage.txt"
+    --html-details "$out_dir/coverage.html"
+  )
+
+  if [[ $no_fail -eq 0 ]]; then
+    args+=(--fail-under-line "$fail_under")
+  fi
+
+  gcovr "${args[@]}"
+
+  echo ""
+  echo "Coverage report: $out_dir/coverage.html"
+  echo "Coverage summary: $out_dir/coverage.txt"
+  exit 0
+fi
+
+# Fallback: lcov/genhtml
+if command -v lcov >/dev/null 2>&1 && command -v genhtml >/dev/null 2>&1; then
+  build_dir="$repo_root/build/${preset}"
+
+  lcov --capture --directory "$build_dir" --output-file "$out_dir/coverage.info" >/dev/null
+  lcov --remove "$out_dir/coverage.info" "/usr/*" "$repo_root/build/*" --output-file "$out_dir/coverage.filtered.info" >/dev/null
+  genhtml "$out_dir/coverage.filtered.info" --output-directory "$out_dir/html" >/dev/null
+
+  lcov --summary "$out_dir/coverage.filtered.info" | tee "$out_dir/coverage.txt"
+
+  if [[ $no_fail -eq 0 ]]; then
+    # Extract line coverage percentage and compare.
+    pct=$(lcov --summary "$out_dir/coverage.filtered.info" | rg -o 'lines\.+: ([0-9]+\.[0-9]+)%' -r '$1' | head -n1 || true)
+    if [[ -n "$pct" ]]; then
+      awk -v pct="$pct" -v min="$fail_under" 'BEGIN { exit !(pct+0 >= min+0) }' || {
+        echo "FAIL: line coverage ${pct}% < ${fail_under}%" >&2
+        exit 1
+      }
+    fi
+  fi
+
+  echo ""
+  echo "Coverage report: $out_dir/html/index.html"
+  echo "Coverage summary: $out_dir/coverage.txt"
+  exit 0
+fi
+
+echo "Neither gcovr nor (lcov+genhtml) is installed." >&2
+echo "Install one of:" >&2
+echo "  sudo apt-get update && sudo apt-get install -y gcovr" >&2
+echo "  sudo apt-get update && sudo apt-get install -y lcov" >&2
+exit 2

--- a/scripts/gh_pr_patch_body.sh
+++ b/scripts/gh_pr_patch_body.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/gh_pr_patch_body.sh <pr-number> <body-file>
+
+Workaround for `gh pr edit` GraphQL failures in repos that still have
+legacy (classic) project cards.
+
+This updates the PR body via the REST API:
+  PATCH /repos/{owner}/{repo}/pulls/{pull_number}
+
+Examples:
+  scripts/gh_pr_patch_body.sh 123 /tmp/new-body.md
+EOF
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+pr_number="$1"
+body_file="$2"
+
+if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+  echo "error: pr-number must be an integer" >&2
+  exit 2
+fi
+
+if [[ ! -f "$body_file" ]]; then
+  echo "error: body-file does not exist: $body_file" >&2
+  exit 2
+fi
+
+repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+python3 - <<'PY' "$repo" "$pr_number" "$body_file" | gh api \
+  --method PATCH \
+  --input - \
+  "repos/$repo/pulls/$pr_number" \
+  >/dev/null
+import json
+import sys
+
+repo = sys.argv[1]
+pr_number = int(sys.argv[2])
+body_file = sys.argv[3]
+
+with open(body_file, 'r', encoding='utf-8') as f:
+    body = f.read()
+
+# `gh api --input -` expects a JSON object.
+print(json.dumps({"body": body}))
+PY
+
+echo "ok: updated PR #$pr_number body via REST (repo=$repo)"

--- a/src/bundle/bundle.cpp
+++ b/src/bundle/bundle.cpp
@@ -333,9 +333,9 @@ BundleResult read_bundle(const std::string& path)
     }
     if (manifest.format_version != kBundleFormatVersion)
     {
-        return BundleError{"unsupported bundle format version: " +
-                           std::to_string(manifest.format_version) +
-                           " (supported: " + std::to_string(kBundleFormatVersion) + ")"};
+        return BundleError{
+            "unsupported bundle format version: " + std::to_string(manifest.format_version) +
+            " (supported: " + std::to_string(kBundleFormatVersion) + ")"};
     }
     if (manifest.bytecode_hash.empty())
     {

--- a/src/compiler/emitter.cpp
+++ b/src/compiler/emitter.cpp
@@ -105,8 +105,8 @@ class Emitter
         {
             if (functions_.contains(f.name))
             {
-                diags_.push_back(
-                    error_at(f.span, "duplicate function declaration '" + std::string(f.name) + "'"));
+                diags_.push_back(error_at(f.span, "duplicate function declaration '" +
+                                                      std::string(f.name) + "'"));
                 return diags_;
             }
             functions_.emplace(f.name, &f);
@@ -180,7 +180,7 @@ class Emitter
     std::uint16_t next_local_base_ = 0;
     bool current_is_main_ = false;
 
-        std::unordered_map<std::string_view, const Function*> functions_;
+    std::unordered_map<std::string_view, const Function*> functions_;
 
     std::unordered_set<std::string> imported_module_keys_;
     std::unordered_map<std::string_view, std::string> imported_module_aliases_;
@@ -239,9 +239,9 @@ class Emitter
             const auto& p = fn.params[i];
             if (p.type.name != "Int" && p.type.name != "Bool")
             {
-                diags_.push_back(error_at(p.type.span,
-                                         "parameter type not supported in runnable code: '" +
-                                             std::string(p.type.name) + "'"));
+                diags_.push_back(
+                    error_at(p.type.span, "parameter type not supported in runnable code: '" +
+                                              std::string(p.type.name) + "'"));
                 return;
             }
 
@@ -702,9 +702,8 @@ class Emitter
             std::vector<std::string_view> parts;
             if (!collect_member_chain(*expr.callee, parts) || parts.size() < 2)
             {
-                diags_.push_back(error_at(span,
-                                          "only name calls and module-qualified calls are "
-                                          "supported in runnable code"));
+                diags_.push_back(error_at(span, "only name calls and module-qualified calls are "
+                                                "supported in runnable code"));
                 return;
             }
 
@@ -730,9 +729,8 @@ class Emitter
 
             if (!qualifier_ok)
             {
-                diags_.push_back(
-                    error_at(span, "unknown module qualifier in runnable call: '" +
-                                      join_path(qualifier) + "'"));
+                diags_.push_back(error_at(span, "unknown module qualifier in runnable call: '" +
+                                                    join_path(qualifier) + "'"));
                 return;
             }
 
@@ -743,9 +741,8 @@ class Emitter
             const auto* callee_name = std::get_if<curlee::parser::NameExpr>(&expr.callee->node);
             if (callee_name == nullptr)
             {
-                diags_.push_back(error_at(span,
-                                          "only name calls and module-qualified calls are "
-                                          "supported in runnable code"));
+                diags_.push_back(error_at(span, "only name calls and module-qualified calls are "
+                                                "supported in runnable code"));
                 return;
             }
             callee_fn_name = callee_name->name;
@@ -762,9 +759,9 @@ class Emitter
         const auto* callee_decl = fn_it->second;
         if (expr.args.size() != callee_decl->params.size())
         {
-            diags_.push_back(error_at(
-                span, "call to '" + std::string(callee_fn_name) + "' expects " +
-                          std::to_string(callee_decl->params.size()) + " argument(s)"));
+            diags_.push_back(
+                error_at(span, "call to '" + std::string(callee_fn_name) + "' expects " +
+                                   std::to_string(callee_decl->params.size()) + " argument(s)"));
             return;
         }
 

--- a/src/diag/render.cpp
+++ b/src/diag/render.cpp
@@ -32,11 +32,6 @@ struct LineSlice
 
 LineSlice slice_for_line(std::string_view text, std::size_t line_start)
 {
-    if (line_start > text.size())
-    {
-        line_start = text.size();
-    }
-
     const std::size_t nl = text.find('\n', line_start);
     const std::size_t line_end = (nl == std::string_view::npos) ? text.size() : nl;
     return LineSlice{.start = line_start, .end = line_end};
@@ -83,7 +78,7 @@ std::string render(const Diagnostic& diagnostic, const curlee::source::SourceFil
     const std::size_t line_len = line_text.size();
 
     // caret_start is 0-based within the line.
-    const std::size_t caret_start = (lc.col == 0) ? 0 : (lc.col - 1);
+    const std::size_t caret_start = lc.col - 1;
 
     std::size_t span_len = 0;
     if (span.end > span.start)
@@ -92,8 +87,7 @@ std::string render(const Diagnostic& diagnostic, const curlee::source::SourceFil
     }
 
     // If the span crosses lines, highlight only the first line.
-    const std::size_t first_line_remaining =
-        (caret_start <= line_len) ? (line_len - caret_start) : 0;
+    const std::size_t first_line_remaining = line_len - caret_start;
     const bool crosses_line = (span.start + span_len > line_slice.end);
 
     std::size_t caret_len = 1;

--- a/src/source/line_map.cpp
+++ b/src/source/line_map.cpp
@@ -27,11 +27,6 @@ LineCol LineMap::offset_to_line_col(std::size_t offset) const
 
     // Find the last line start <= offset.
     auto it = std::upper_bound(line_starts_.begin(), line_starts_.end(), offset);
-    if (it == line_starts_.begin())
-    {
-        return LineCol{.line = 1, .col = 1 + offset};
-    }
-
     const std::size_t index = static_cast<std::size_t>(std::distance(line_starts_.begin(), it) - 1);
     const std::size_t start = line_starts_[index];
 

--- a/src/source/line_map.cpp
+++ b/src/source/line_map.cpp
@@ -12,27 +12,13 @@ LineMap::LineMap(std::string_view text) : text_size_(text.size())
         if (text[i] == '\n')
         {
             const std::size_t next = i + 1;
-            if (next <= text.size())
-            {
-                line_starts_.push_back(next);
-            }
+            line_starts_.push_back(next);
         }
-    }
-
-    // Ensure at least one line.
-    if (line_starts_.empty())
-    {
-        line_starts_.push_back(0);
     }
 }
 
 LineCol LineMap::offset_to_line_col(std::size_t offset) const
 {
-    if (line_starts_.empty())
-    {
-        return LineCol{.line = 1, .col = 1};
-    }
-
     // Clamp to end-of-text.
     if (offset > text_size_)
     {
@@ -59,11 +45,6 @@ std::size_t LineMap::line_start_offset(std::size_t line) const
         return 0;
     }
 
-    if (line_starts_.empty())
-    {
-        return 0;
-    }
-
     const std::size_t index = line - 1;
     if (index >= line_starts_.size())
     {
@@ -75,7 +56,7 @@ std::size_t LineMap::line_start_offset(std::size_t line) const
 
 std::size_t LineMap::line_count() const
 {
-    return line_starts_.empty() ? 1 : line_starts_.size();
+    return line_starts_.size();
 }
 
 } // namespace curlee::source

--- a/src/source/source_file.cpp
+++ b/src/source/source_file.cpp
@@ -5,14 +5,8 @@
 namespace curlee::source
 {
 
-LoadResult load_source_file(const std::string& path)
+LoadResult load_source_stream(std::istream& in, const std::string& path)
 {
-    std::ifstream in(path, std::ios::in | std::ios::binary);
-    if (!in)
-    {
-        return LoadError{.message = "failed to open file"};
-    }
-
     std::ostringstream buffer;
     buffer << in.rdbuf();
 
@@ -22,6 +16,17 @@ LoadResult load_source_file(const std::string& path)
     }
 
     return SourceFile{.path = path, .contents = buffer.str()};
+}
+
+LoadResult load_source_file(const std::string& path)
+{
+    std::ifstream in(path, std::ios::in | std::ios::binary);
+    if (!in)
+    {
+        return LoadError{.message = "failed to open file"};
+    }
+
+    return load_source_stream(in, path);
 }
 
 } // namespace curlee::source

--- a/src/types/type_check.cpp
+++ b/src/types/type_check.cpp
@@ -138,8 +138,8 @@ class Checker
 
   private:
     std::unordered_map<std::string_view, FunctionType> functions_;
-        std::unordered_set<std::string> imported_module_keys_;
-        std::unordered_map<std::string_view, std::string> imported_module_aliases_;
+    std::unordered_set<std::string> imported_module_keys_;
+    std::unordered_map<std::string_view, std::string> imported_module_aliases_;
     std::vector<Scope> scopes_;
     std::vector<Diagnostic> diags_;
     TypeInfo info_;
@@ -766,8 +766,7 @@ class Checker
 
             if (!qualifier_ok)
             {
-                error_at(span, "unknown module qualifier in call: '" + join_path(qualifier) +
-                                   "'");
+                error_at(span, "unknown module qualifier in call: '" + join_path(qualifier) + "'");
                 return std::nullopt;
             }
 
@@ -811,8 +810,8 @@ class Checker
         // Builtin placeholder signatures may not match; only user functions are checked here.
         if (e.args.size() != sig.params.size())
         {
-            error_at(span, "wrong number of arguments for call to '" +
-                               std::string(callee_name) + "'");
+            error_at(span,
+                     "wrong number of arguments for call to '" + std::string(callee_name) + "'");
             return std::nullopt;
         }
 
@@ -825,8 +824,8 @@ class Checker
             }
             if (*arg_t != sig.params[i])
             {
-                error_at(span, "argument type mismatch for call to '" +
-                                   std::string(callee_name) + "'");
+                error_at(span,
+                         "argument type mismatch for call to '" + std::string(callee_name) + "'");
             }
         }
 

--- a/src/types/type_check.cpp
+++ b/src/types/type_check.cpp
@@ -33,6 +33,45 @@ using curlee::parser::UnsafeStmt;
 using curlee::parser::WhileStmt;
 using curlee::source::Span;
 
+static std::string join_path(const std::vector<std::string_view>& parts)
+{
+    std::string out;
+    for (std::size_t i = 0; i < parts.size(); ++i)
+    {
+        out += std::string(parts[i]);
+        if (i + 1 < parts.size())
+        {
+            out += '.';
+        }
+    }
+    return out;
+}
+
+static bool collect_member_chain(const Expr& expr, std::vector<std::string_view>& out)
+{
+    if (const auto* name = std::get_if<NameExpr>(&expr.node))
+    {
+        out.push_back(name->name);
+        return true;
+    }
+
+    if (const auto* mem = std::get_if<MemberExpr>(&expr.node))
+    {
+        if (mem->base == nullptr)
+        {
+            return false;
+        }
+        if (!collect_member_chain(*mem->base, out))
+        {
+            return false;
+        }
+        out.push_back(mem->member);
+        return true;
+    }
+
+    return false;
+}
+
 struct Scope
 {
     std::unordered_map<std::string_view, Type> vars;
@@ -43,6 +82,18 @@ class Checker
   public:
     [[nodiscard]] TypeCheckResult run(const curlee::parser::Program& program)
     {
+        imported_module_keys_.clear();
+        imported_module_aliases_.clear();
+        for (const auto& imp : program.imports)
+        {
+            const std::string key = join_path(imp.path);
+            imported_module_keys_.insert(key);
+            if (imp.alias.has_value())
+            {
+                imported_module_aliases_.emplace(*imp.alias, key);
+            }
+        }
+
         collect_structs_and_enums(program);
 
         // Builtins (compiler/runtime-provided).
@@ -87,6 +138,8 @@ class Checker
 
   private:
     std::unordered_map<std::string_view, FunctionType> functions_;
+        std::unordered_set<std::string> imported_module_keys_;
+        std::unordered_map<std::string_view, std::string> imported_module_aliases_;
     std::vector<Scope> scopes_;
     std::vector<Diagnostic> diags_;
     TypeInfo info_;
@@ -674,14 +727,59 @@ class Checker
             return Type{.kind = TypeKind::Enum, .name = callee_scoped->lhs};
         }
 
-        const auto* callee_name = std::get_if<NameExpr>(&e.callee->node);
-        if (callee_name == nullptr)
+        std::string_view callee_name;
+        if (const auto* callee_direct = std::get_if<NameExpr>(&e.callee->node);
+            callee_direct != nullptr)
+        {
+            callee_name = callee_direct->name;
+        }
+        else if (const auto* callee_member = std::get_if<MemberExpr>(&e.callee->node);
+                 callee_member != nullptr)
+        {
+            // Module-qualified call: either `alias.fn(...)` or `foo.bar.fn(...)`.
+            std::vector<std::string_view> parts;
+            if (!collect_member_chain(*e.callee, parts) || parts.size() < 2)
+            {
+                error_at(span, "only direct calls are supported (callee must be a name)");
+                return std::nullopt;
+            }
+
+            const std::string_view member = parts.back();
+            const std::vector<std::string_view> qualifier(parts.begin(), parts.end() - 1);
+
+            bool qualifier_ok = false;
+            if (qualifier.size() == 1)
+            {
+                if (imported_module_aliases_.contains(qualifier[0]))
+                {
+                    qualifier_ok = true;
+                }
+            }
+            if (!qualifier_ok)
+            {
+                const std::string key = join_path(qualifier);
+                if (imported_module_keys_.contains(key))
+                {
+                    qualifier_ok = true;
+                }
+            }
+
+            if (!qualifier_ok)
+            {
+                error_at(span, "unknown module qualifier in call: '" + join_path(qualifier) +
+                                   "'");
+                return std::nullopt;
+            }
+
+            callee_name = member;
+        }
+        else
         {
             error_at(span, "only direct calls are supported (callee must be a name)");
             return std::nullopt;
         }
 
-        if (callee_name->name == "print")
+        if (callee_name == "print")
         {
             if (e.args.size() != 1)
             {
@@ -702,10 +800,10 @@ class Checker
             return Type{.kind = TypeKind::Unit};
         }
 
-        const auto it = functions_.find(callee_name->name);
+        const auto it = functions_.find(callee_name);
         if (it == functions_.end())
         {
-            error_at(span, "unknown function '" + std::string(callee_name->name) + "'");
+            error_at(span, "unknown function '" + std::string(callee_name) + "'");
             return std::nullopt;
         }
 
@@ -714,7 +812,7 @@ class Checker
         if (e.args.size() != sig.params.size())
         {
             error_at(span, "wrong number of arguments for call to '" +
-                               std::string(callee_name->name) + "'");
+                               std::string(callee_name) + "'");
             return std::nullopt;
         }
 
@@ -728,7 +826,7 @@ class Checker
             if (*arg_t != sig.params[i])
             {
                 error_at(span, "argument type mismatch for call to '" +
-                                   std::string(callee_name->name) + "'");
+                                   std::string(callee_name) + "'");
             }
         }
 

--- a/src/verification/solver.cpp
+++ b/src/verification/solver.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cassert>
 #include <curlee/verification/solver.h>
 
 namespace curlee::verification
@@ -56,10 +57,8 @@ std::optional<Model> Solver::model_for(const std::vector<z3::expr>& vars) const
     {
         return std::nullopt;
     }
-    if (!last_model_.has_value())
-    {
-        return std::nullopt;
-    }
+
+    assert(last_model_.has_value());
 
     Model model;
     model.entries.reserve(vars.size());

--- a/tests/cli_bad_args_tests.cpp
+++ b/tests/cli_bad_args_tests.cpp
@@ -116,6 +116,19 @@ int main()
         expect_contains(err, "error: expected capability name after --cap", "stderr");
     }
 
+    // run: --capability alias
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture(
+            {"curlee", "run", "--capability", "io:stdout", "--fuel", "0"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for missing run file (with --capability)");
+        }
+        expect_contains(err, "error: expected <file.curlee>", "stderr");
+    }
+
     // run: empty --cap=
     {
         std::string out;
@@ -160,6 +173,18 @@ int main()
         if (rc != 2)
         {
             fail("expected usage exit code for invalid --fuel=");
+        }
+        expect_contains(err, "error: expected non-negative integer for --fuel=", "stderr");
+    }
+
+    // run: empty --fuel=
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--fuel=", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for empty --fuel=");
         }
         expect_contains(err, "error: expected non-negative integer for --fuel=", "stderr");
     }
@@ -211,6 +236,19 @@ int main()
             fail("expected usage exit code for multiple <file.curlee>");
         }
         expect_contains(err, "error: expected a single <file.curlee>", "stderr");
+    }
+
+    // run: bundle load failure path
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture(
+            {"curlee", "run", "--bundle", "definitely_missing.bundle", "x.curlee"}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for failed bundle load");
+        }
+        expect_contains(err, "error: failed to load bundle: failed to open bundle", "stderr");
     }
 
     // fmt: wrong args

--- a/tests/cli_bad_args_tests.cpp
+++ b/tests/cli_bad_args_tests.cpp
@@ -164,6 +164,55 @@ int main()
         expect_contains(err, "error: expected non-negative integer for --fuel=", "stderr");
     }
 
+    // run: missing value after --bundle
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--bundle"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for missing --bundle arg");
+        }
+        expect_contains(err, "error: expected bundle path after --bundle", "stderr");
+    }
+
+    // run: empty --bundle=
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--bundle=", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for empty --bundle=");
+        }
+        expect_contains(err, "error: expected bundle path after --bundle=", "stderr");
+    }
+
+    // run: duplicate --bundle
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture(
+            {"curlee", "run", "--bundle", "a.bundle", "--bundle", "b.bundle"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for duplicate --bundle");
+        }
+        expect_contains(err, "error: expected a single --bundle <file.bundle>", "stderr");
+    }
+
+    // run: multiple positional <file.curlee>
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "a.curlee", "b.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for multiple <file.curlee>");
+        }
+        expect_contains(err, "error: expected a single <file.curlee>", "stderr");
+    }
+
     // fmt: wrong args
     {
         std::string out;

--- a/tests/cli_bad_args_tests.cpp
+++ b/tests/cli_bad_args_tests.cpp
@@ -1,0 +1,234 @@
+#include <cstdlib>
+#include <curlee/bundle/bundle.h>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static fs::path find_repo_relative(const fs::path& relative)
+{
+    fs::path dir = fs::current_path();
+    for (int i = 0; i < 8; ++i)
+    {
+        const fs::path candidate = dir / relative;
+        if (fs::exists(candidate))
+        {
+            return candidate;
+        }
+        if (!dir.has_parent_path())
+        {
+            break;
+        }
+        dir = dir.parent_path();
+    }
+    fail("unable to locate repo-relative path: " + relative.string());
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static fs::path temp_path(const std::string& name)
+{
+    return fs::temp_directory_path() / name;
+}
+
+int main()
+{
+    const fs::path fixture =
+        find_repo_relative(fs::path("tests") / "fixtures" / "run_success.curlee");
+
+    // run: missing <file.curlee>
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for missing run file");
+        }
+        expect_contains(err, "error: expected <file.curlee>", "stderr");
+    }
+
+    // run: unknown option
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--nope", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for unknown option");
+        }
+        expect_contains(err, "error: unknown option: --nope", "stderr");
+    }
+
+    // run: missing value after --cap
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--cap"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for missing --cap arg");
+        }
+        expect_contains(err, "error: expected capability name after --cap", "stderr");
+    }
+
+    // run: empty --cap=
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--cap=", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for empty --cap=");
+        }
+        expect_contains(err, "error: expected capability name after --cap=", "stderr");
+    }
+
+    // run: missing value after --fuel
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--fuel"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for missing --fuel arg");
+        }
+        expect_contains(err, "error: expected integer after --fuel", "stderr");
+    }
+
+    // run: invalid --fuel
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--fuel", "abc", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for invalid --fuel value");
+        }
+        expect_contains(err, "error: expected non-negative integer for --fuel", "stderr");
+    }
+
+    // run: invalid --fuel=
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "run", "--fuel=abc", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for invalid --fuel=");
+        }
+        expect_contains(err, "error: expected non-negative integer for --fuel=", "stderr");
+    }
+
+    // fmt: wrong args
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "fmt"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for fmt missing args");
+        }
+        expect_contains(err, "error: expected curlee fmt", "stderr");
+    }
+
+    // bundle: wrong args
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "bundle"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for bundle missing args");
+        }
+        expect_contains(err, "error: expected curlee bundle", "stderr");
+    }
+
+    // bundle: unknown subcommand (requires a valid bundle file to reach the branch)
+    {
+        const fs::path bundle_path = temp_path("curlee_cli_bundle_unknown_subcmd.bundle");
+        fs::remove(bundle_path);
+
+        curlee::bundle::Bundle bundle;
+        bundle.manifest.capabilities = {"io:stdout"};
+        bundle.manifest.imports = {};
+        bundle.manifest.proof = std::nullopt;
+        bundle.bytecode = {0x01, 0x02, 0x03, 0x04};
+
+        const auto write_err = curlee::bundle::write_bundle(bundle_path.string(), bundle);
+        if (!write_err.message.empty())
+        {
+            fail("expected bundle write to succeed");
+        }
+
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "bundle", "wat", bundle_path.string()}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for unknown bundle subcommand");
+        }
+        expect_contains(err, "error: unknown bundle subcommand: wat", "stderr");
+
+        fs::remove(bundle_path);
+    }
+
+    // cmd_read_only: unknown command requires a valid source file to load.
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "wat", fixture.string()}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for unknown read-only command");
+        }
+        expect_contains(err, "error: unknown command: wat", "stderr");
+    }
+
+    std::cout << "OK\n";
+    return 0;
+}

--- a/tests/cli_bundle_golden_tests.cpp
+++ b/tests/cli_bundle_golden_tests.cpp
@@ -53,10 +53,8 @@ static int run_cli(const std::vector<std::string>& argv_storage, std::string& ou
     return rc;
 }
 
-static void run_golden_case(const fs::path& stdout_golden,
-                            const fs::path& stderr_golden,
-                            const std::vector<std::string>& argv,
-                            bool expect_success)
+static void run_golden_case(const fs::path& stdout_golden, const fs::path& stderr_golden,
+                            const std::vector<std::string>& argv, bool expect_success)
 {
     std::string out;
     std::string err;
@@ -105,16 +103,14 @@ int main(int argc, char** argv)
         const fs::path bundle = golden_dir / "current_v1.bundle";
         run_golden_case(golden_dir / "current_v1.stdout.golden",
                         golden_dir / "current_v1.stderr.golden",
-                        {"curlee", "bundle", "info", bundle.string()},
-                        true);
+                        {"curlee", "bundle", "info", bundle.string()}, true);
     }
 
     {
         const fs::path bundle = golden_dir / "future_v2.bundle";
         run_golden_case(golden_dir / "future_v2.stdout.golden",
                         golden_dir / "future_v2.stderr.golden",
-                        {"curlee", "bundle", "verify", bundle.string()},
-                        false);
+                        {"curlee", "bundle", "verify", bundle.string()}, false);
     }
 
     std::cout << "OK\n";

--- a/tests/cli_check_duplicate_function_tests.cpp
+++ b/tests/cli_check_duplicate_function_tests.cpp
@@ -1,0 +1,111 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static void write_file(const fs::path& path, const std::string& contents)
+{
+    fs::create_directories(path.parent_path());
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open file: " + path.string());
+    }
+
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write file: " + path.string());
+    }
+}
+
+int main()
+{
+    // check: duplicate function name across imported modules.
+    {
+        const auto pid = static_cast<unsigned long>(::getpid());
+        const fs::path dir =
+            fs::temp_directory_path() / ("curlee_cli_dup_fn_" + std::to_string(pid));
+
+        // Entry imports a and b; both define foo().
+        write_file(dir / "entry.curlee",
+                   "import a;\nimport b;\n\nfn main() -> Int {\n  return 0;\n}\n");
+
+        write_file(dir / "a.curlee", "fn foo() -> Int {\n  return 1;\n}\n");
+        write_file(dir / "b.curlee", "fn foo() -> Int {\n  return 2;\n}\n");
+
+        std::string out;
+        std::string err;
+        const int rc =
+            run_cli_capture({"curlee", "check", (dir / "entry.curlee").string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for duplicate imported function");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "duplicate function across modules: 'foo'", "stderr");
+        expect_contains(err, "conflict while importing", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_check_import_cycle_tests.cpp
+++ b/tests/cli_check_import_cycle_tests.cpp
@@ -1,0 +1,113 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static void write_file(const fs::path& path, const std::string& contents)
+{
+    fs::create_directories(path.parent_path());
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open file: " + path.string());
+    }
+
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write file: " + path.string());
+    }
+}
+
+int main()
+{
+    // check: import cycle detected (a <-> b)
+    {
+        const auto pid = static_cast<unsigned long>(::getpid());
+        const fs::path dir =
+            fs::temp_directory_path() / ("curlee_cli_cycle_" + std::to_string(pid));
+
+        // entry imports a
+        write_file(dir / "entry.curlee", "import a;\n\nfn main() -> Int {\n  return 0;\n}\n");
+
+        // a imports b
+        write_file(dir / "a.curlee", "import b;\n\nfn f() -> Int {\n  return 0;\n}\n");
+
+        // b imports a (cycle)
+        write_file(dir / "b.curlee", "import a;\n\nfn g() -> Int {\n  return 0;\n}\n");
+
+        std::string out;
+        std::string err;
+        const int rc =
+            run_cli_capture({"curlee", "check", (dir / "entry.curlee").string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for import cycle");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "import cycle detected", "stderr");
+        expect_contains(err, "cycle involves", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_check_import_depth_tests.cpp
+++ b/tests/cli_check_import_depth_tests.cpp
@@ -1,0 +1,122 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static void write_file(const fs::path& path, const std::string& contents)
+{
+    fs::create_directories(path.parent_path());
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open file: " + path.string());
+    }
+
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write file: " + path.string());
+    }
+}
+
+static std::string fn_body_return_zero(const std::string& name)
+{
+    return "fn " + name + "() -> Int {\n  return 0;\n}\n";
+}
+
+int main()
+{
+    // check: hit the max import depth guard (kMaxImportDepth=64)
+    {
+        const auto pid = static_cast<unsigned long>(::getpid());
+        const fs::path dir =
+            fs::temp_directory_path() / ("curlee_cli_depth_" + std::to_string(pid));
+
+        // Entry imports m0.
+        write_file(dir / "entry.curlee", "import m0;\n\nfn main() -> Int {\n  return 0;\n}\n");
+
+        // m0 -> m1 -> ... -> m63 -> m64
+        // Depth is 1 at m0, so m64 is depth 65 and should trigger the guard (depth > 64).
+        for (int i = 0; i < 64; ++i)
+        {
+            const std::string mod = "m" + std::to_string(i);
+            const std::string next = "m" + std::to_string(i + 1);
+            write_file(dir / (mod + ".curlee"),
+                       "import " + next + ";\n\n" + fn_body_return_zero("f" + std::to_string(i)));
+        }
+        write_file(dir / "m64.curlee", fn_body_return_zero("f64"));
+
+        std::string out;
+        std::string err;
+        const int rc =
+            run_cli_capture({"curlee", "check", (dir / "entry.curlee").string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for deep import graph");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "import graph too deep", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_check_import_error_tests.cpp
+++ b/tests/cli_check_import_error_tests.cpp
@@ -1,0 +1,117 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static fs::path write_temp_curlee(const std::string& stem, const std::string& contents)
+{
+    const auto pid = static_cast<unsigned long>(::getpid());
+    const fs::path dir = fs::temp_directory_path() / "curlee_cli_tests";
+
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec)
+    {
+        fail("failed to create temp dir: " + dir.string() + ": " + ec.message());
+    }
+
+    const fs::path path = dir / (stem + "_" + std::to_string(pid) + ".curlee");
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open temp file: " + path.string());
+    }
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write temp file: " + path.string());
+    }
+
+    return path;
+}
+
+int main()
+{
+    // check: missing import produces a deterministic CLI diagnostic.
+    {
+        const std::string import_path = "missing.module";
+        const fs::path entry = write_temp_curlee("check_import_not_found",
+                                                 "import " + import_path +
+                                                     ";\n\nfn main() -> Int {\n  return 0;\n}\n");
+
+        const fs::path expected = entry.parent_path() / "missing" / "module.curlee";
+
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "check", entry.string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for check import failure");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "import not found: '" + import_path + "'", "stderr");
+        expect_contains(err, "expected module at " + expected.string(), "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_check_import_order_tests.cpp
+++ b/tests/cli_check_import_order_tests.cpp
@@ -1,0 +1,116 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static fs::path write_temp_curlee(const std::string& stem, const std::string& contents)
+{
+    const auto pid = static_cast<unsigned long>(::getpid());
+    const fs::path dir = fs::temp_directory_path() / "curlee_cli_tests";
+
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec)
+    {
+        fail("failed to create temp dir: " + dir.string() + ": " + ec.message());
+    }
+
+    const fs::path path = dir / (stem + "_" + std::to_string(pid) + ".curlee");
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open temp file: " + path.string());
+    }
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write temp file: " + path.string());
+    }
+
+    return path;
+}
+
+int main()
+{
+    // check: parser rejects imports after other top-level declarations.
+    {
+        const fs::path entry = write_temp_curlee(
+            "check_import_order", "fn main() -> Int {\n  return 0;\n}\n\nimport a;\n");
+
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "check", entry.string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for import-after-declaration");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err,
+                        "import declarations must appear before any other top-level declarations",
+                        "stderr");
+        expect_contains(err, "move this import above the first declaration", "stderr");
+        expect_contains(err, "first declaration is here", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_check_import_path_tests.cpp
+++ b/tests/cli_check_import_path_tests.cpp
@@ -1,0 +1,112 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static fs::path write_temp_curlee(const std::string& stem, const std::string& contents)
+{
+    const auto pid = static_cast<unsigned long>(::getpid());
+    const fs::path dir = fs::temp_directory_path() / "curlee_cli_tests";
+
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec)
+    {
+        fail("failed to create temp dir: " + dir.string() + ": " + ec.message());
+    }
+
+    const fs::path path = dir / (stem + "_" + std::to_string(pid) + ".curlee");
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open temp file: " + path.string());
+    }
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write temp file: " + path.string());
+    }
+
+    return path;
+}
+
+int main()
+{
+    // check: parser rejects "import a.;" (missing identifier after '.')
+    {
+        const fs::path entry = write_temp_curlee(
+            "check_import_path", "import a.;\n\nfn main() -> Int {\n  return 0;\n}\n");
+
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "check", entry.string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for malformed import path");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "expected identifier after '.' in import path", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_check_imported_main_tests.cpp
+++ b/tests/cli_check_imported_main_tests.cpp
@@ -1,0 +1,107 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static void write_file(const fs::path& path, const std::string& contents)
+{
+    fs::create_directories(path.parent_path());
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open file: " + path.string());
+    }
+
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write file: " + path.string());
+    }
+}
+
+int main()
+{
+    // check: imported modules must not define 'main'
+    {
+        const auto pid = static_cast<unsigned long>(::getpid());
+        const fs::path dir =
+            fs::temp_directory_path() / ("curlee_cli_imported_main_" + std::to_string(pid));
+
+        write_file(dir / "entry.curlee", "import mod;\n\nfn main() -> Int {\n  return 0;\n}\n");
+
+        write_file(dir / "mod.curlee", "fn main() -> Int {\n  return 0;\n}\n");
+
+        std::string out;
+        std::string err;
+        const int rc =
+            run_cli_capture({"curlee", "check", (dir / "entry.curlee").string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for imported module defining main");
+        }
+
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "imported modules must not define 'main'", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/cli_diagnostics_golden_tests.cpp
+++ b/tests/cli_diagnostics_golden_tests.cpp
@@ -194,6 +194,49 @@ static bool run_check_requires_if_path_sensitive_case(const fs::path& golden_pat
     return true;
 }
 
+static bool run_check_requires_while_condition_fact_case(const fs::path& golden_path)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_cout = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_cerr = std::cerr.rdbuf(captured_err.rdbuf());
+
+    const std::string rel_path = "tests/fixtures/check_requires_while_condition_fact.curlee";
+
+    std::vector<std::string> argv_storage = {"curlee", "check", rel_path};
+    std::vector<char*> argv;
+    argv.reserve(argv_storage.size());
+    for (auto& s : argv_storage)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_cout);
+    std::cerr.rdbuf(old_cerr);
+
+    const std::string got = captured_err.str();
+    const std::string expected = slurp(golden_path);
+
+    if (rc != 0)
+    {
+        std::cerr << "expected zero exit code for check-requires-while-condition-fact\n";
+        return false;
+    }
+
+    if (got != expected)
+    {
+        std::cerr << "GOLDEN MISMATCH: " << golden_path.filename().string() << "\n";
+        std::cerr << "--- expected ---\n" << expected;
+        std::cerr << "--- got ---\n" << got;
+        return false;
+    }
+
+    return true;
+}
+
 static bool run_run_requires_divide_case(const fs::path& golden_path)
 {
     std::ostringstream captured_out;
@@ -771,6 +814,8 @@ int main(int argc, char** argv)
     const fs::path check_refinement_implies_golden = dir / "check_refinement_implies.golden";
     const fs::path check_requires_if_path_sensitive_golden =
         dir / "check_requires_if_path_sensitive.golden";
+    const fs::path check_requires_while_condition_fact_golden =
+        dir / "check_requires_while_condition_fact.golden";
     const fs::path check_unknown_name_golden = dir / "check_unknown_name.golden";
     const fs::path check_type_error_golden = dir / "check_type_error.golden";
     const fs::path check_if_condition_type_error_golden =
@@ -842,6 +887,12 @@ int main(int argc, char** argv)
         }
 
         if (!run_check_requires_if_path_sensitive_case(check_requires_if_path_sensitive_golden))
+        {
+            return 1;
+        }
+
+        if (!run_check_requires_while_condition_fact_case(
+                check_requires_while_condition_fact_golden))
         {
             return 1;
         }

--- a/tests/cli_diagnostics_golden_tests.cpp
+++ b/tests/cli_diagnostics_golden_tests.cpp
@@ -151,6 +151,49 @@ static bool run_check_refinement_implies_case(const fs::path& golden_path)
     return true;
 }
 
+static bool run_check_requires_if_path_sensitive_case(const fs::path& golden_path)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_cout = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_cerr = std::cerr.rdbuf(captured_err.rdbuf());
+
+    const std::string rel_path = "tests/fixtures/check_requires_if_path_sensitive.curlee";
+
+    std::vector<std::string> argv_storage = {"curlee", "check", rel_path};
+    std::vector<char*> argv;
+    argv.reserve(argv_storage.size());
+    for (auto& s : argv_storage)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_cout);
+    std::cerr.rdbuf(old_cerr);
+
+    const std::string got = captured_err.str();
+    const std::string expected = slurp(golden_path);
+
+    if (rc != 0)
+    {
+        std::cerr << "expected zero exit code for check-requires-if-path-sensitive\n";
+        return false;
+    }
+
+    if (got != expected)
+    {
+        std::cerr << "GOLDEN MISMATCH: " << golden_path.filename().string() << "\n";
+        std::cerr << "--- expected ---\n" << expected;
+        std::cerr << "--- got ---\n" << got;
+        return false;
+    }
+
+    return true;
+}
+
 static bool run_run_requires_divide_case(const fs::path& golden_path)
 {
     std::ostringstream captured_out;
@@ -726,6 +769,8 @@ int main(int argc, char** argv)
     const fs::path golden = dir / "missing_file.golden";
     const fs::path check_requires_divide_golden = dir / "check_requires_divide.golden";
     const fs::path check_refinement_implies_golden = dir / "check_refinement_implies.golden";
+    const fs::path check_requires_if_path_sensitive_golden =
+        dir / "check_requires_if_path_sensitive.golden";
     const fs::path check_unknown_name_golden = dir / "check_unknown_name.golden";
     const fs::path check_type_error_golden = dir / "check_type_error.golden";
     const fs::path check_if_condition_type_error_golden =
@@ -792,6 +837,11 @@ int main(int argc, char** argv)
         }
 
         if (!run_check_refinement_implies_case(check_refinement_implies_golden))
+        {
+            return 1;
+        }
+
+        if (!run_check_requires_if_path_sensitive_case(check_requires_if_path_sensitive_golden))
         {
             return 1;
         }

--- a/tests/cli_fmt_tests.cpp
+++ b/tests/cli_fmt_tests.cpp
@@ -136,6 +136,40 @@ int main()
         }
     }
 
+    // Runnable imports: module-qualified function calls should work.
+    {
+        const fs::path fixture =
+            find_repo_relative(fs::path("tests") / "fixtures" / "qualified_call" / "main.curlee");
+
+        std::ostringstream captured_out;
+        std::ostringstream captured_err;
+        auto* old_cout = std::cout.rdbuf(captured_out.rdbuf());
+        auto* old_cerr = std::cerr.rdbuf(captured_err.rdbuf());
+
+        std::vector<std::string> argv_storage = {"curlee", "run", fixture.string()};
+        std::vector<char*> argv;
+        argv.reserve(argv_storage.size());
+        for (auto& s : argv_storage)
+        {
+            argv.push_back(s.data());
+        }
+
+        const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+        std::cout.rdbuf(old_cout);
+        std::cerr.rdbuf(old_cerr);
+
+        if (rc != 0)
+        {
+            fail("expected imported-module run to succeed; stderr: " + captured_err.str());
+        }
+
+        const std::string out = captured_out.str();
+        if (out.find("curlee run: result 42") == std::string::npos)
+        {
+            fail("expected imported-module run output to include result 42");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/cli_fmt_tests.cpp
+++ b/tests/cli_fmt_tests.cpp
@@ -108,7 +108,8 @@ int main()
 
     // Shorthand: `curlee <file.curlee>` behaves like `curlee run <file.curlee>`.
     {
-        const fs::path fixture = find_repo_relative(fs::path("tests") / "fixtures" / "run_success.curlee");
+        const fs::path fixture =
+            find_repo_relative(fs::path("tests") / "fixtures" / "run_success.curlee");
 
         std::ostringstream captured;
         auto* old_buf = std::cout.rdbuf(captured.rdbuf());

--- a/tests/cli_lex_parse_error_tests.cpp
+++ b/tests/cli_lex_parse_error_tests.cpp
@@ -1,0 +1,124 @@
+#include <cstdlib>
+#include <curlee/cli/cli.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+[[noreturn]] static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+static int run_cli_capture(const std::vector<std::string>& argv_storage, std::string& out,
+                           std::string& err)
+{
+    std::ostringstream captured_out;
+    std::ostringstream captured_err;
+
+    auto* old_out = std::cout.rdbuf(captured_out.rdbuf());
+    auto* old_err = std::cerr.rdbuf(captured_err.rdbuf());
+
+    std::vector<std::string> args = argv_storage;
+    std::vector<char*> argv;
+    argv.reserve(args.size());
+    for (auto& s : args)
+    {
+        argv.push_back(s.data());
+    }
+
+    const int rc = curlee::cli::run(static_cast<int>(argv.size()), argv.data());
+
+    std::cout.rdbuf(old_out);
+    std::cerr.rdbuf(old_err);
+
+    out = captured_out.str();
+    err = captured_err.str();
+    return rc;
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const std::string& what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        fail("expected " + what + " to contain '" + needle + "'\n---\n" + haystack + "\n---");
+    }
+}
+
+static void expect_empty(const std::string& s, const std::string& what)
+{
+    if (!s.empty())
+    {
+        fail("expected " + what + " to be empty\n---\n" + s + "\n---");
+    }
+}
+
+static fs::path write_temp_curlee(const std::string& stem, const std::string& contents)
+{
+    const auto pid = static_cast<unsigned long>(::getpid());
+    const fs::path dir = fs::temp_directory_path() / "curlee_cli_tests";
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    if (ec)
+    {
+        fail("failed to create temp dir: " + dir.string() + ": " + ec.message());
+    }
+
+    const fs::path path = dir / (stem + "_" + std::to_string(pid) + ".curlee");
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f)
+    {
+        fail("failed to open temp file: " + path.string());
+    }
+    f << contents;
+    if (!f)
+    {
+        fail("failed to write temp file: " + path.string());
+    }
+
+    return path;
+}
+
+int main()
+{
+    // lex: lexer error is surfaced as a diagnostic
+    {
+        const fs::path path = write_temp_curlee("lex_error", "@\n");
+
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "lex", path.string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for lex error");
+        }
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+        expect_contains(err, "invalid character", "stderr");
+    }
+
+    // parse: parser error is surfaced as one or more diagnostics
+    {
+        const fs::path path = write_temp_curlee("parse_error", "fn\n");
+
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "parse", path.string()}, out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit code for parse error");
+        }
+        expect_empty(out, "stdout");
+        expect_contains(err, "error:", "stderr");
+    }
+
+    return 0;
+}

--- a/tests/compiler_tests.cpp
+++ b/tests/compiler_tests.cpp
@@ -172,6 +172,74 @@ int main()
     }
 
     {
+        const std::string source =
+            "fn inc(x: Int) -> Int { return x + 1; } fn main() -> Int { return inc(41); }";
+
+        const auto chunk = compile_to_chunk(source);
+        const auto res = run_chunk(chunk);
+        if (!res.ok || !(res.value == curlee::vm::Value::int_v(42)))
+        {
+            fail("expected inc(41) to equal 42");
+        }
+    }
+
+    {
+        const std::string source =
+            "fn add(x: Int, y: Int) -> Int { return x + y; } fn main() -> Int { return add(1, 2); }";
+
+        const auto chunk = compile_to_chunk(source);
+        const auto res = run_chunk(chunk);
+        if (!res.ok || !(res.value == curlee::vm::Value::int_v(3)))
+        {
+            fail("expected add(1,2) to equal 3");
+        }
+    }
+
+    {
+        const std::string source =
+            "fn negate(x: Bool) -> Bool { return !x; } fn main() -> Bool { return negate(false); }";
+
+        const auto chunk = compile_to_chunk(source);
+        const auto res = run_chunk(chunk);
+        if (!res.ok || !(res.value == curlee::vm::Value::bool_v(true)))
+        {
+            fail("expected negate(false) to equal true");
+        }
+    }
+
+    {
+        const std::string source =
+            "fn f(x: String) -> Int { return 1; } fn main() -> Int { return 0; }";
+
+        const auto lexed = curlee::lexer::lex(source);
+        if (std::holds_alternative<curlee::diag::Diagnostic>(lexed))
+        {
+            fail("expected lexing to succeed for unsupported param type case");
+        }
+
+        const auto& tokens = std::get<std::vector<curlee::lexer::Token>>(lexed);
+        const auto parsed = curlee::parser::parse(tokens);
+        if (std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(parsed))
+        {
+            fail("expected parsing to succeed for unsupported param type case");
+        }
+
+        const auto& program = std::get<curlee::parser::Program>(parsed);
+        const auto emitted = curlee::compiler::emit_bytecode(program);
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(emitted))
+        {
+            fail("expected bytecode emission to fail for unsupported parameter types");
+        }
+
+        const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(emitted);
+        if (diags.empty() || diags[0].message.find("parameter type not supported in runnable code") ==
+                                 std::string::npos)
+        {
+            fail("expected diagnostic for unsupported parameter type in runnable code");
+        }
+    }
+
+    {
         const std::string source = "fn main() -> Int { return -1; }";
         const auto chunk = compile_to_chunk(source);
         const auto ops = decode_ops(chunk);

--- a/tests/compiler_tests.cpp
+++ b/tests/compiler_tests.cpp
@@ -184,8 +184,8 @@ int main()
     }
 
     {
-        const std::string source =
-            "fn add(x: Int, y: Int) -> Int { return x + y; } fn main() -> Int { return add(1, 2); }";
+        const std::string source = "fn add(x: Int, y: Int) -> Int { return x + y; } fn main() -> "
+                                   "Int { return add(1, 2); }";
 
         const auto chunk = compile_to_chunk(source);
         const auto res = run_chunk(chunk);
@@ -232,8 +232,9 @@ int main()
         }
 
         const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(emitted);
-        if (diags.empty() || diags[0].message.find("parameter type not supported in runnable code") ==
-                                 std::string::npos)
+        if (diags.empty() ||
+            diags[0].message.find("parameter type not supported in runnable code") ==
+                std::string::npos)
         {
             fail("expected diagnostic for unsupported parameter type in runnable code");
         }

--- a/tests/diag_render_tests.cpp
+++ b/tests/diag_render_tests.cpp
@@ -52,6 +52,19 @@ int main()
         expect_contains(out, "note: helpful", "span note");
     }
 
+    // Zero-length span: should still render a single caret.
+    {
+        curlee::diag::Diagnostic diag;
+        diag.severity = curlee::diag::Severity::Error;
+        diag.message = "point";
+        diag.span = curlee::source::Span{.start = 3, .end = 3}; // newline at end of line 1
+
+        const std::string out = curlee::diag::render(diag, file);
+        expect_contains(out, "test.curlee:1:4: error: point", "zero-length header");
+        expect_contains(out, "| abc", "zero-length line");
+        expect_contains(out, "^", "zero-length caret");
+    }
+
     // Multi-line span: only highlight first line.
     {
         curlee::diag::Diagnostic diag;

--- a/tests/diag_render_tests.cpp
+++ b/tests/diag_render_tests.cpp
@@ -1,0 +1,82 @@
+#include <cstdlib>
+#include <curlee/diag/diagnostic.h>
+#include <curlee/diag/render.h>
+#include <curlee/source/source_file.h>
+#include <iostream>
+#include <string>
+
+static void expect_contains(const std::string& got, const std::string& needle, const char* what)
+{
+    if (got.find(needle) == std::string::npos)
+    {
+        std::cerr << "FAIL: " << what << ": expected output to contain: '" << needle << "'\n";
+        std::cerr << "Got:\n" << got << "\n";
+        std::exit(1);
+    }
+}
+
+int main()
+{
+    const curlee::source::SourceFile file{
+        .path = "test.curlee",
+        .contents = "abc\n"  // line 1
+                    "defg\n" // line 2
+                    "hi\n",  // line 3
+    };
+
+    // No-span diagnostic: should render file path + severity + message and notes.
+    {
+        curlee::diag::Diagnostic diag;
+        diag.severity = curlee::diag::Severity::Warning;
+        diag.message = "something happened";
+        diag.span = std::nullopt;
+        diag.notes.push_back(curlee::diag::Related{.message = "note 1", .span = std::nullopt});
+
+        const std::string out = curlee::diag::render(diag, file);
+        expect_contains(out, "test.curlee: warning: something happened", "no-span header");
+        expect_contains(out, "note: note 1", "no-span note");
+    }
+
+    // Span diagnostic: caret highlights within a line.
+    {
+        curlee::diag::Diagnostic diag;
+        diag.severity = curlee::diag::Severity::Error;
+        diag.message = "bad";
+        diag.span = curlee::source::Span{.start = 5, .end = 7}; // "ef" in line 2
+        diag.notes.push_back(curlee::diag::Related{.message = "helpful", .span = std::nullopt});
+
+        const std::string out = curlee::diag::render(diag, file);
+        expect_contains(out, "test.curlee:2:2: error: bad", "span header");
+        expect_contains(out, "| defg", "source line");
+        expect_contains(out, "^^", "caret len");
+        expect_contains(out, "note: helpful", "span note");
+    }
+
+    // Multi-line span: only highlight first line.
+    {
+        curlee::diag::Diagnostic diag;
+        diag.severity = curlee::diag::Severity::Error;
+        diag.message = "cross";
+        diag.span = curlee::source::Span{.start = 2, .end = 100};
+
+        const std::string out = curlee::diag::render(diag, file);
+        expect_contains(out, "test.curlee:1:3: error: cross", "multiline header");
+        expect_contains(out, "| abc", "multiline line");
+        // Should not print a giant run of carets; at least one caret.
+        expect_contains(out, "^", "multiline caret");
+    }
+
+    // Invalid enum value hits the default severity_string() fallback.
+    {
+        curlee::diag::Diagnostic diag;
+        diag.severity = static_cast<curlee::diag::Severity>(123);
+        diag.message = "unknown severity";
+        diag.span = std::nullopt;
+
+        const std::string out = curlee::diag::render(diag, file);
+        expect_contains(out, "test.curlee: error: unknown severity", "invalid severity fallback");
+    }
+
+    std::cout << "OK\n";
+    return 0;
+}

--- a/tests/e2e_tests.cpp
+++ b/tests/e2e_tests.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cstdlib>
 #include <curlee/compiler/emitter.h>
 #include <curlee/lexer/lexer.h>
 #include <curlee/parser/parser.h>
@@ -6,11 +8,8 @@
 #include <curlee/types/type_check.h>
 #include <curlee/verification/checker.h>
 #include <curlee/vm/vm.h>
-
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -103,7 +102,8 @@ static void check_program(const fs::path& path, bool run_vm)
             }
 
             const auto start = static_cast<std::size_t>(result.error_span->start);
-            const auto len = static_cast<std::size_t>(result.error_span->end - result.error_span->start);
+            const auto len =
+                static_cast<std::size_t>(result.error_span->end - result.error_span->start);
             const std::string_view slice(contents.data() + start, len);
             if (slice.find('/') == std::string_view::npos)
             {

--- a/tests/fixtures/check_requires_if_path_sensitive.curlee
+++ b/tests/fixtures/check_requires_if_path_sensitive.curlee
@@ -1,0 +1,15 @@
+fn take_nonzero(x: Int) -> Int [
+  requires x != 0;
+] {
+  return x;
+}
+
+fn main() -> Int {
+  let x: Int = 0;
+
+  if (x != 0) {
+    return take_nonzero(x);
+  } else {
+    return 0;
+  }
+}

--- a/tests/fixtures/check_requires_while_condition_fact.curlee
+++ b/tests/fixtures/check_requires_while_condition_fact.curlee
@@ -1,0 +1,16 @@
+fn take_pos(x: Int) -> Int [
+  requires x > 0;
+] {
+  return x;
+}
+
+fn main() -> Int {
+  let x: Int = 1;
+
+  while (x > 0) {
+    // Verifier should assume the loop condition inside the body.
+    return take_pos(x);
+  }
+
+  return 0;
+}

--- a/tests/fixtures/qualified_call/main.curlee
+++ b/tests/fixtures/qualified_call/main.curlee
@@ -1,0 +1,6 @@
+import mymod.math as m;
+
+fn main() -> Int {
+  // Both alias-qualified and path-qualified calls should work.
+  return m.add1(41) + mymod.math.add1(-1);
+}

--- a/tests/fixtures/qualified_call/mymod/math.curlee
+++ b/tests/fixtures/qualified_call/mymod/math.curlee
@@ -1,0 +1,3 @@
+fn add1(x: Int) -> Int {
+  return x + 1;
+}

--- a/tests/header_smoke_tests.cpp
+++ b/tests/header_smoke_tests.cpp
@@ -1,0 +1,85 @@
+#include <cstdlib>
+#include <curlee/resolver/symbol.h>
+#include <curlee/types/type.h>
+#include <curlee/types/type_check.h>
+#include <iostream>
+
+static void expect_true(bool v, const char* what)
+{
+    if (!v)
+    {
+        std::cerr << "FAIL: expected true: " << what << "\n";
+        std::exit(1);
+    }
+}
+
+static void expect_false(bool v, const char* what)
+{
+    if (v)
+    {
+        std::cerr << "FAIL: expected false: " << what << "\n";
+        std::exit(1);
+    }
+}
+
+static void expect_eq(std::string_view got, std::string_view expected, const char* what)
+{
+    if (got != expected)
+    {
+        std::cerr << "FAIL: " << what << ": got='" << got << "' expected='" << expected << "'\n";
+        std::exit(1);
+    }
+}
+
+int main()
+{
+    using namespace curlee;
+
+    // resolver::SymbolId comparisons
+    {
+        resolver::SymbolId a{.value = 1};
+        resolver::SymbolId b{.value = 1};
+        resolver::SymbolId c{.value = 2};
+        expect_true(a == b, "SymbolId ==");
+        expect_false(a != b, "SymbolId != false");
+        expect_true(a != c, "SymbolId != true");
+    }
+
+    // types::Type comparisons and formatting
+    {
+        const types::Type i{.kind = types::TypeKind::Int};
+        const types::Type b{.kind = types::TypeKind::Bool};
+        expect_true(i == i, "Type Int == Int");
+        expect_false(i == b, "Type Int != Bool");
+
+        const types::Type s1{.kind = types::TypeKind::Struct, .name = "S"};
+        const types::Type s2{.kind = types::TypeKind::Struct, .name = "S"};
+        const types::Type s3{.kind = types::TypeKind::Struct, .name = "T"};
+        expect_true(s1 == s2, "Struct name equality");
+        expect_false(s1 == s3, "Struct name inequality");
+
+        expect_eq(types::to_string(types::TypeKind::Int), "Int", "to_string(TypeKind::Int)");
+        expect_eq(types::to_string(static_cast<types::TypeKind>(123)), "<unknown>",
+                  "to_string(TypeKind invalid)");
+
+        expect_eq(types::to_string(i), "Int", "to_string(Type Int)");
+        expect_eq(types::to_string(s1), "S", "to_string(Type Struct)");
+
+        expect_true(types::core_type_from_name("Bool").has_value(), "core_type_from_name Bool");
+        expect_false(types::core_type_from_name("NotAType").has_value(),
+                     "core_type_from_name unknown");
+    }
+
+    // types::TypeInfo::type_of
+    {
+        types::TypeInfo info;
+        expect_false(info.type_of(1).has_value(), "type_of absent");
+        info.expr_types.emplace(1, types::Type{.kind = types::TypeKind::Unit});
+        const auto got = info.type_of(1);
+        expect_true(got.has_value(), "type_of present");
+        expect_true(*got == types::Type{.kind = types::TypeKind::Unit}, "type_of value");
+    }
+
+    std::cout << "OK\n";
+    return 0;
+}

--- a/tests/lexer_fuzz.cpp
+++ b/tests/lexer_fuzz.cpp
@@ -1,7 +1,6 @@
-#include <curlee/lexer/lexer.h>
-
 #include <cstddef>
 #include <cstdint>
+#include <curlee/lexer/lexer.h>
 #include <fstream>
 #include <iterator>
 #include <string>
@@ -9,30 +8,32 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, std::size_t size)
 {
-  const std::string input(reinterpret_cast<const char*>(data), size);
+    const std::string input(reinterpret_cast<const char*>(data), size);
 
-  // Determinism/capability rule: lexer must be driven only by input bytes.
-  // We intentionally ignore the result; the fuzzer is looking for crashes/UB.
-  (void)curlee::lexer::lex(input);
+    // Determinism/capability rule: lexer must be driven only by input bytes.
+    // We intentionally ignore the result; the fuzzer is looking for crashes/UB.
+    (void)curlee::lexer::lex(input);
 
-  return 0;
+    return 0;
 }
 
 #ifdef CURLEE_FUZZER_STANDALONE
 int main(int argc, char** argv)
 {
-  if(argc != 2)
-  {
-    return 2;
-  }
+    if (argc != 2)
+    {
+        return 2;
+    }
 
-  std::ifstream in(argv[1], std::ios::binary);
-  if(!in)
-  {
-    return 2;
-  }
+    std::ifstream in(argv[1], std::ios::binary);
+    if (!in)
+    {
+        return 2;
+    }
 
-  const std::vector<char> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-  return LLVMFuzzerTestOneInput(reinterpret_cast<const std::uint8_t*>(bytes.data()), bytes.size());
+    const std::vector<char> bytes((std::istreambuf_iterator<char>(in)),
+                                  std::istreambuf_iterator<char>());
+    return LLVMFuzzerTestOneInput(reinterpret_cast<const std::uint8_t*>(bytes.data()),
+                                  bytes.size());
 }
 #endif

--- a/tests/line_map_tests.cpp
+++ b/tests/line_map_tests.cpp
@@ -44,6 +44,30 @@ int main()
         expect_eq(lc.col, 4, "end col"); // "def" length 3 => col 4 at end
     }
 
+    {
+        const auto lc = map.offset_to_line_col(text.size() + 123); // clamp past end
+        expect_eq(lc.line, 3, "clamped end line");
+        expect_eq(lc.col, 4, "clamped end col");
+    }
+
+    {
+        expect_eq(map.line_start_offset(0), 0, "line 0 start offset");
+    }
+
+    {
+        expect_eq(map.line_start_offset(1), 0, "line 1 start offset");
+        expect_eq(map.line_start_offset(2), 2, "line 2 start offset");
+        expect_eq(map.line_start_offset(3), 5, "line 3 start offset");
+    }
+
+    {
+        expect_eq(map.line_start_offset(999), text.size(), "too-large line start offset");
+    }
+
+    {
+        expect_eq(map.line_count(), 3, "line_count");
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/source_file_tests.cpp
+++ b/tests/source_file_tests.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <variant>
 
@@ -56,6 +57,23 @@ int main()
         }
         const auto& err = std::get<LoadError>(res);
         if (err.message != "failed to open file")
+        {
+            fail("unexpected error message: " + err.message);
+        }
+    }
+
+    // Read-failure path.
+    {
+        std::istringstream in("hello");
+        in.setstate(std::ios::badbit);
+
+        const auto res = load_source_stream(in, "synthetic.curlee");
+        if (!std::holds_alternative<LoadError>(res))
+        {
+            fail("expected LoadError for bad stream");
+        }
+        const auto& err = std::get<LoadError>(res);
+        if (err.message != "failed while reading file")
         {
             fail("unexpected error message: " + err.message);
         }

--- a/tests/source_file_tests.cpp
+++ b/tests/source_file_tests.cpp
@@ -1,0 +1,67 @@
+#include <cstdlib>
+#include <curlee/source/source_file.h>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <variant>
+
+static void fail(const std::string& msg)
+{
+    std::cerr << "FAIL: " << msg << "\n";
+    std::exit(1);
+}
+
+int main()
+{
+    namespace fs = std::filesystem;
+    using namespace curlee::source;
+
+    const fs::path tmp = fs::path{"source_file_tests_tmp.curlee"};
+    (void)fs::remove(tmp);
+
+    {
+        std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+        if (!out)
+        {
+            fail("failed to create temp file");
+        }
+        out << "hello\nworld";
+    }
+
+    // Success path.
+    {
+        const auto res = load_source_file(tmp.string());
+        if (!std::holds_alternative<SourceFile>(res))
+        {
+            fail("expected SourceFile for readable temp file");
+        }
+        const auto& sf = std::get<SourceFile>(res);
+        if (sf.path != tmp.string())
+        {
+            fail("unexpected path");
+        }
+        if (sf.contents != "hello\nworld")
+        {
+            fail("unexpected contents");
+        }
+    }
+
+    // Open-failure path.
+    {
+        const auto res = load_source_file("this_file_should_not_exist_hopefully.curlee");
+        if (!std::holds_alternative<LoadError>(res))
+        {
+            fail("expected LoadError for missing file");
+        }
+        const auto& err = std::get<LoadError>(res);
+        if (err.message != "failed to open file")
+        {
+            fail("unexpected error message: " + err.message);
+        }
+    }
+
+    (void)fs::remove(tmp);
+    std::cout << "OK\n";
+    return 0;
+}

--- a/tests/tensor_ir_tests.cpp
+++ b/tests/tensor_ir_tests.cpp
@@ -27,5 +27,17 @@ int main()
         fail("unexpected dump output\n--- got ---\n" + got + "--- expected ---\n" + expected);
     }
 
+    // Edge cases: unknown dtype formatting + empty shape.
+    {
+        Program p2;
+        (void)p2.zeros(Shape{{}}, static_cast<DType>(123));
+
+        const auto got2 = p2.dump();
+        if (got2 != "%0 = zeros <unknown>[]\n")
+        {
+            fail("unexpected dump output (edge cases)\n--- got ---\n" + got2 + "--- expected ---\n%0 = zeros <unknown>[]\n");
+        }
+    }
+
     return 0;
 }

--- a/tests/tensor_ir_tests.cpp
+++ b/tests/tensor_ir_tests.cpp
@@ -35,7 +35,8 @@ int main()
         const auto got2 = p2.dump();
         if (got2 != "%0 = zeros <unknown>[]\n")
         {
-            fail("unexpected dump output (edge cases)\n--- got ---\n" + got2 + "--- expected ---\n%0 = zeros <unknown>[]\n");
+            fail("unexpected dump output (edge cases)\n--- got ---\n" + got2 +
+                 "--- expected ---\n%0 = zeros <unknown>[]\n");
         }
     }
 

--- a/tests/verification_solver_tests.cpp
+++ b/tests/verification_solver_tests.cpp
@@ -12,6 +12,18 @@ int main()
 {
     using namespace curlee::verification;
 
+    // model_for() before any check() should return nullopt.
+    {
+        Solver solver;
+        auto& ctx = solver.context();
+        auto x = ctx.int_const("x");
+
+        if (solver.model_for({x}).has_value())
+        {
+            fail("expected no model before check()");
+        }
+    }
+
     {
         Solver solver;
         auto& ctx = solver.context();
@@ -78,6 +90,36 @@ int main()
         if (rendered != "x = 7\ny = 3")
         {
             fail("expected deterministic model formatting order");
+        }
+    }
+
+    // push()/pop() should clear cached results and models.
+    {
+        Solver solver;
+        auto& ctx = solver.context();
+        auto x = ctx.int_const("x");
+        solver.add(x == 1);
+
+        if (solver.check() != CheckResult::Sat)
+        {
+            fail("expected satisfiable constraints for push/pop test");
+        }
+
+        if (!solver.model_for({x}).has_value())
+        {
+            fail("expected model before push()");
+        }
+
+        solver.push();
+        if (solver.model_for({x}).has_value())
+        {
+            fail("expected no model after push() (cache cleared)");
+        }
+
+        solver.pop();
+        if (solver.model_for({x}).has_value())
+        {
+            fail("expected no model after pop() (cache cleared)");
         }
     }
 


### PR DESCRIPTION
Add concise Doxygen-style documentation to public headers to improve API clarity and developer ergonomics. Includes formatting changes from clang-format.