### PR TITLE
CI: gate coverage on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,21 @@ jobs:
       - name: Smoke (release)
         if: matrix.preset == 'linux-release'
         run: bash scripts/smoke.sh --preset linux-release --skip-build
+
+  coverage-gate:
+    name: Coverage Gate (linux-debug-coverage)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build g++ gcovr libz3-dev pkg-config ripgrep
+
+      - name: Coverage
+        run: |
+          bash scripts/coverage.sh --fail-under 100 --fail-under-branch 100 --fail-under-function 100


### PR DESCRIPTION
Adds a coverage gate job to CI that runs Preset CMake variables:

  CMAKE_BUILD_TYPE="Debug"
  CMAKE_CXX_FLAGS="-O0 -g --coverage"
  CMAKE_EXE_LINKER_FLAGS="--coverage"
  CMAKE_EXPORT_COMPILE_COMMANDS="ON"
  CMAKE_INSTALL_PREFIX:PATH="/home/joe/Projects/curlee/build/linux-debug-coverage/install"
  CMAKE_SHARED_LINKER_FLAGS="--coverage"

-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/joe/Projects/curlee/build/linux-debug-coverage
[1/256] Building CXX object CMakeFiles/curlee.dir/src/main.cpp.o
[2/256] Building CXX object CMakeFiles/curlee.dir/src/source/line_map.cpp.o
[3/256] Building CXX object CMakeFiles/curlee.dir/src/source/source_file.cpp.o
[4/256] Building CXX object CMakeFiles/curlee.dir/src/diag/render.cpp.o
[5/256] Building CXX object CMakeFiles/curlee.dir/src/lexer/lexer.cpp.o
[6/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/diag/render.cpp.o
[7/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/lexer/lexer.cpp.o
[8/256] Building CXX object CMakeFiles/curlee.dir/src/verification/solver.cpp.o
[9/256] Building CXX object CMakeFiles/curlee.dir/src/bundle/bundle.cpp.o
[10/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/bundle/bundle.cpp.o
[11/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/source/line_map.cpp.o
[12/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/tests/cli_diagnostics_golden_tests.cpp.o
[13/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/source/source_file.cpp.o
[14/256] Building CXX object CMakeFiles/curlee.dir/src/verification/predicate_lowering.cpp.o
[15/256] Building CXX object CMakeFiles/curlee.dir/src/vm/vm.cpp.o
[16/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/tests/cli_fmt_tests.cpp.o
[17/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/verification/solver.cpp.o
[18/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/compiler/emitter.cpp.o
[19/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/bundle/bundle.cpp.o
[20/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/verification/predicate_lowering.cpp.o
[21/256] Building CXX object CMakeFiles/curlee.dir/src/compiler/emitter.cpp.o
[22/256] Building CXX object CMakeFiles/curlee.dir/src/types/type_check.cpp.o
[23/256] Building CXX object CMakeFiles/curlee.dir/src/verification/checker.cpp.o
[24/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/lexer/lexer.cpp.o
[25/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/diag/render.cpp.o
[26/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/vm/vm.cpp.o
[27/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/source/line_map.cpp.o
[28/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/source/source_file.cpp.o
[29/256] Building CXX object CMakeFiles/curlee.dir/src/resolver/resolver.cpp.o
[30/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/resolver/resolver.cpp.o
[31/256] Building CXX object CMakeFiles/curlee.dir/src/cli/cli.cpp.o
[32/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/cli/cli.cpp.o
[33/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/types/type_check.cpp.o
[34/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/verification/checker.cpp.o
[35/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/verification/predicate_lowering.cpp.o
[36/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/verification/solver.cpp.o
[37/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/diag/render.cpp.o
[38/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/compiler/emitter.cpp.o
[39/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/bundle/bundle.cpp.o
[40/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/source/line_map.cpp.o
[41/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/tests/cli_bundle_tests.cpp.o
[42/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/lexer/lexer.cpp.o
[43/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/source/source_file.cpp.o
[44/256] Building CXX object CMakeFiles/curlee.dir/src/parser/parser.cpp.o
[45/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/vm/vm.cpp.o
[46/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/cli/cli.cpp.o
[47/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/types/type_check.cpp.o
[48/256] Linking CXX executable curlee
[49/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/resolver/resolver.cpp.o
[50/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/tests/cli_bundle_golden_tests.cpp.o
[51/256] Building CXX object CMakeFiles/curlee_cli_diagnostics_golden_tests.dir/src/parser/parser.cpp.o
[52/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/verification/solver.cpp.o
[53/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/bundle/bundle.cpp.o
[54/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/verification/checker.cpp.o
[55/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/verification/predicate_lowering.cpp.o
[56/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/diag/render.cpp.o
[57/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/lexer/lexer.cpp.o
[58/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/source/line_map.cpp.o
[59/256] Linking CXX executable curlee_cli_diagnostics_golden_tests
[60/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/compiler/emitter.cpp.o
[61/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/source/source_file.cpp.o
[62/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/tests/cli_version_tests.cpp.o
[63/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/vm/vm.cpp.o
[64/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/resolver/resolver.cpp.o
[65/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/verification/solver.cpp.o
[66/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/types/type_check.cpp.o
[67/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/bundle/bundle.cpp.o
[68/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/diag/render.cpp.o
[69/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/verification/predicate_lowering.cpp.o
[70/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/compiler/emitter.cpp.o
[71/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/verification/checker.cpp.o
[72/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/cli/cli.cpp.o
[73/256] Building CXX object CMakeFiles/curlee_cli_fmt_tests.dir/src/parser/parser.cpp.o
[74/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/source/line_map.cpp.o
[75/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/lexer/lexer.cpp.o
[76/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/source/source_file.cpp.o
[77/256] Linking CXX executable curlee_cli_fmt_tests
[78/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/vm/vm.cpp.o
[79/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/types/type_check.cpp.o
[80/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/resolver/resolver.cpp.o
[81/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/verification/predicate_lowering.cpp.o
[82/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/cli/cli.cpp.o
[83/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/verification/solver.cpp.o
[84/256] Building CXX object CMakeFiles/curlee_cli_bundle_tests.dir/src/parser/parser.cpp.o
[85/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/bundle/bundle.cpp.o
[86/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/verification/checker.cpp.o
[87/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/diag/render.cpp.o
[88/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/compiler/emitter.cpp.o
[89/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/lexer/lexer.cpp.o
[90/256] Linking CXX executable curlee_cli_bundle_tests
[91/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/tests/cli_bad_args_tests.cpp.o
[92/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/source/line_map.cpp.o
[93/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/source/source_file.cpp.o
[94/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/vm/vm.cpp.o
[95/256] Building CXX object CMakeFiles/curlee_cli_bundle_golden_tests.dir/src/parser/parser.cpp.o
[96/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/types/type_check.cpp.o
[97/256] Linking CXX executable curlee_cli_bundle_golden_tests
[98/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/verification/solver.cpp.o
[99/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/tests/cli_lex_parse_error_tests.cpp.o
[100/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/resolver/resolver.cpp.o
[101/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/verification/checker.cpp.o
[102/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/verification/predicate_lowering.cpp.o
[103/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/bundle/bundle.cpp.o
[104/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/diag/render.cpp.o
[105/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/cli/cli.cpp.o
[106/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/source/line_map.cpp.o
[107/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/source/source_file.cpp.o
[108/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/compiler/emitter.cpp.o
[109/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/lexer/lexer.cpp.o
[110/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/resolver/resolver.cpp.o
[111/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/vm/vm.cpp.o
[112/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/verification/checker.cpp.o
[113/256] Building CXX object CMakeFiles/curlee_cli_version_tests.dir/src/parser/parser.cpp.o
[114/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/cli/cli.cpp.o
[115/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/bundle/bundle.cpp.o
[116/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/verification/solver.cpp.o
[117/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/types/type_check.cpp.o
[118/256] Linking CXX executable curlee_cli_version_tests
[119/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/source/line_map.cpp.o
[120/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/lexer/lexer.cpp.o
[121/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/verification/predicate_lowering.cpp.o
[122/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/compiler/emitter.cpp.o
[123/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/tests/cli_check_import_error_tests.cpp.o
[124/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/diag/render.cpp.o
[125/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/source/source_file.cpp.o
[126/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/vm/vm.cpp.o
[127/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/tests/cli_check_import_cycle_tests.cpp.o
[128/256] Building CXX object CMakeFiles/curlee_cli_bad_args_tests.dir/src/parser/parser.cpp.o
[129/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/verification/solver.cpp.o
[130/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/cli/cli.cpp.o
[131/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/verification/checker.cpp.o
[132/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/types/type_check.cpp.o
[133/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/compiler/emitter.cpp.o
[134/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/bundle/bundle.cpp.o
[135/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/resolver/resolver.cpp.o
[136/256] Linking CXX executable curlee_cli_bad_args_tests
[137/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/source/line_map.cpp.o
[138/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/verification/predicate_lowering.cpp.o
[139/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/vm/vm.cpp.o
[140/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/diag/render.cpp.o
[141/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/lexer/lexer.cpp.o
[142/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/source/source_file.cpp.o
[143/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/verification/checker.cpp.o
[144/256] Building CXX object CMakeFiles/curlee_cli_lex_parse_error_tests.dir/src/parser/parser.cpp.o
[145/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/resolver/resolver.cpp.o
[146/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/types/type_check.cpp.o
[147/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/bundle/bundle.cpp.o
[148/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/compiler/emitter.cpp.o
[149/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/verification/solver.cpp.o
[150/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/tests/cli_check_import_depth_tests.cpp.o
[151/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/cli/cli.cpp.o
[152/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/verification/predicate_lowering.cpp.o
[153/256] Linking CXX executable curlee_cli_lex_parse_error_tests
[154/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/source/line_map.cpp.o
[155/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/diag/render.cpp.o
[156/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/vm/vm.cpp.o
[157/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/lexer/lexer.cpp.o
[158/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/source/source_file.cpp.o
[159/256] Building CXX object CMakeFiles/curlee_cli_check_import_error_tests.dir/src/parser/parser.cpp.o
[160/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/tests/cli_check_imported_main_tests.cpp.o
[161/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/verification/solver.cpp.o
[162/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/resolver/resolver.cpp.o
[163/256] Linking CXX executable curlee_cli_check_import_error_tests
[164/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/verification/predicate_lowering.cpp.o
[165/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/verification/checker.cpp.o
[166/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/types/type_check.cpp.o
[167/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/cli/cli.cpp.o
[168/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/bundle/bundle.cpp.o
[169/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/source/line_map.cpp.o
[170/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/diag/render.cpp.o
[171/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/source/source_file.cpp.o
[172/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/lexer/lexer.cpp.o
[173/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/compiler/emitter.cpp.o
[174/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/vm/vm.cpp.o
[175/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/types/type_check.cpp.o
[176/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/tests/cli_check_duplicate_function_tests.cpp.o
[177/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/verification/checker.cpp.o
[178/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/cli/cli.cpp.o
[179/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/diag/render.cpp.o
[180/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/bundle/bundle.cpp.o
[181/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/verification/predicate_lowering.cpp.o
[182/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/resolver/resolver.cpp.o
[183/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/verification/solver.cpp.o
[184/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/lexer/lexer.cpp.o
[185/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/compiler/emitter.cpp.o
[186/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/source/line_map.cpp.o
[187/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/vm/vm.cpp.o
[188/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/source/source_file.cpp.o
[189/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/verification/checker.cpp.o
[190/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/cli/cli.cpp.o
[191/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/types/type_check.cpp.o
[192/256] Building CXX object CMakeFiles/curlee_cli_check_import_cycle_tests.dir/src/parser/parser.cpp.o
[193/256] Building CXX object CMakeFiles/curlee_cli_check_import_depth_tests.dir/src/parser/parser.cpp.o
[194/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/verification/solver.cpp.o
[195/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/tests/cli_check_import_order_tests.cpp.o
[196/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/verification/predicate_lowering.cpp.o
[197/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/bundle/bundle.cpp.o
[198/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/diag/render.cpp.o
[199/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/compiler/emitter.cpp.o
[200/256] Linking CXX executable curlee_cli_check_import_cycle_tests
[201/256] Linking CXX executable curlee_cli_check_import_depth_tests
[202/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/resolver/resolver.cpp.o
[203/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/source/line_map.cpp.o
[204/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/source/source_file.cpp.o
[205/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/lexer/lexer.cpp.o
[206/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/vm/vm.cpp.o
[207/256] Building CXX object CMakeFiles/curlee_cli_check_imported_main_tests.dir/src/parser/parser.cpp.o
[208/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/verification/checker.cpp.o
[209/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/tests/cli_check_import_path_tests.cpp.o
[210/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/cli/cli.cpp.o
[211/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/types/type_check.cpp.o
[212/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/bundle/bundle.cpp.o
[213/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/verification/solver.cpp.o
[214/256] Linking CXX executable curlee_cli_check_imported_main_tests
[215/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/verification/predicate_lowering.cpp.o
[216/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/resolver/resolver.cpp.o
[217/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/diag/render.cpp.o
[218/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/lexer/lexer.cpp.o
[219/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/compiler/emitter.cpp.o
[220/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/source/line_map.cpp.o
[221/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/source/source_file.cpp.o
[222/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/resolver/resolver.cpp.o
[223/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/vm/vm.cpp.o
[224/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/tests/cli_fuel_tests.cpp.o
[225/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/cli/cli.cpp.o
[226/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/verification/checker.cpp.o
[227/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/verification/solver.cpp.o
[228/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/types/type_check.cpp.o
[229/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/bundle/bundle.cpp.o
[230/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/diag/render.cpp.o
[231/256] Building CXX object CMakeFiles/curlee_cli_check_duplicate_function_tests.dir/src/parser/parser.cpp.o
[232/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/lexer/lexer.cpp.o
[233/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/compiler/emitter.cpp.o
[234/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/verification/predicate_lowering.cpp.o
[235/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/source/line_map.cpp.o
[236/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/source/source_file.cpp.o
[237/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/vm/vm.cpp.o
[238/256] Linking CXX executable curlee_cli_check_duplicate_function_tests
[239/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/verification/checker.cpp.o
[240/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/verification/solver.cpp.o
[241/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/cli/cli.cpp.o
[242/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/types/type_check.cpp.o
[243/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/resolver/resolver.cpp.o
[244/256] Building CXX object CMakeFiles/curlee_cli_check_import_order_tests.dir/src/parser/parser.cpp.o
[245/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/compiler/emitter.cpp.o
[246/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/verification/predicate_lowering.cpp.o
[247/256] Linking CXX executable curlee_cli_check_import_order_tests
[248/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/vm/vm.cpp.o
[249/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/types/type_check.cpp.o
[250/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/resolver/resolver.cpp.o
[251/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/cli/cli.cpp.o
[252/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/verification/checker.cpp.o
[253/256] Building CXX object CMakeFiles/curlee_cli_check_import_path_tests.dir/src/parser/parser.cpp.o
[254/256] Linking CXX executable curlee_cli_check_import_path_tests
[255/256] Building CXX object CMakeFiles/curlee_cli_fuel_tests.dir/src/parser/parser.cpp.o
[256/256] Linking CXX executable curlee_cli_fuel_tests
Test project /home/joe/Projects/curlee/build/linux-debug-coverage
      Start  1: curlee_install_smoke
 1/55 Test  #1: curlee_install_smoke ...........................   Passed    0.08 sec
      Start  2: curlee_help
 2/55 Test  #2: curlee_help ....................................   Passed    0.01 sec
      Start  3: curlee_no_args
 3/55 Test  #3: curlee_no_args .................................   Passed    0.01 sec
      Start  4: curlee_missing_file
 4/55 Test  #4: curlee_missing_file ............................   Passed    0.01 sec
      Start  5: curlee_lex_reads_file
 5/55 Test  #5: curlee_lex_reads_file ..........................   Passed    0.01 sec
      Start  6: curlee_line_map_tests
 6/55 Test  #6: curlee_line_map_tests ..........................   Passed    0.00 sec
      Start  7: curlee_source_file_tests
 7/55 Test  #7: curlee_source_file_tests .......................   Passed    0.00 sec
      Start  8: curlee_diagnostic_golden_tests
 8/55 Test  #8: curlee_diagnostic_golden_tests .................   Passed    0.00 sec
      Start  9: curlee_diag_render_tests
 9/55 Test  #9: curlee_diag_render_tests .......................   Passed    0.00 sec
      Start 10: curlee_header_smoke_tests
10/55 Test #10: curlee_header_smoke_tests ......................   Passed    0.00 sec
      Start 11: curlee_python_runner_fake_hang_smoke
11/55 Test #11: curlee_python_runner_fake_hang_smoke ...........   Passed    0.01 sec
      Start 12: curlee_python_runner_fake_spam_smoke
12/55 Test #12: curlee_python_runner_fake_spam_smoke ...........   Passed    0.01 sec
      Start 13: curlee_bwrap_fake_smoke
13/55 Test #13: curlee_bwrap_fake_smoke ........................   Passed    0.00 sec
      Start 14: curlee_bwrap_fake_exec
14/55 Test #14: curlee_bwrap_fake_exec .........................   Passed    0.00 sec
      Start 15: curlee_fake_exes_tests
15/55 Test #15: curlee_fake_exes_tests .........................   Passed    0.01 sec
      Start 16: curlee_cli_diagnostics_golden_tests
16/55 Test #16: curlee_cli_diagnostics_golden_tests ............   Passed    0.64 sec
      Start 17: curlee_lexer_tests
17/55 Test #17: curlee_lexer_tests .............................   Passed    0.00 sec
      Start 18: curlee_parser_tests
18/55 Test #18: curlee_parser_tests ............................   Passed    0.01 sec
      Start 19: curlee_lsp_hover_golden_tests
19/55 Test #19: curlee_lsp_hover_golden_tests ..................   Passed    0.13 sec
      Start 20: curlee_lsp_internal_tests
20/55 Test #20: curlee_lsp_internal_tests ......................   Passed    0.01 sec
      Start 21: curlee_fuzz_regression_tests
21/55 Test #21: curlee_fuzz_regression_tests ...................   Passed    0.00 sec
      Start 22: curlee_resolver_tests
22/55 Test #22: curlee_resolver_tests ..........................   Passed    0.01 sec
      Start 23: curlee_parser_internal_tests
23/55 Test #23: curlee_parser_internal_tests ...................   Passed    0.00 sec
      Start 24: curlee_types_tests
24/55 Test #24: curlee_types_tests .............................   Passed    0.01 sec
      Start 25: curlee_types_extra_tests
25/55 Test #25: curlee_types_extra_tests .......................   Passed    0.01 sec
      Start 26: curlee_training_data_tests
26/55 Test #26: curlee_training_data_tests .....................   Passed    0.09 sec
      Start 27: curlee_cli_fmt_tests
27/55 Test #27: curlee_cli_fmt_tests ...........................   Passed    0.11 sec
      Start 28: curlee_cli_version_tests
28/55 Test #28: curlee_cli_version_tests .......................   Passed    0.01 sec
      Start 29: curlee_cli_bad_args_tests
29/55 Test #29: curlee_cli_bad_args_tests ......................   Passed    0.01 sec
      Start 30: curlee_cli_lex_parse_error_tests
30/55 Test #30: curlee_cli_lex_parse_error_tests ...............   Passed    0.02 sec
      Start 31: curlee_cli_check_import_error_tests
31/55 Test #31: curlee_cli_check_import_error_tests ............   Passed    0.10 sec
      Start 32: curlee_cli_check_import_cycle_tests
32/55 Test #32: curlee_cli_check_import_cycle_tests ............   Passed    0.01 sec
      Start 33: curlee_cli_check_import_depth_tests
33/55 Test #33: curlee_cli_check_import_depth_tests ............   Passed    0.01 sec
      Start 34: curlee_cli_check_imported_main_tests
34/55 Test #34: curlee_cli_check_imported_main_tests ...........   Passed    0.01 sec
      Start 35: curlee_cli_check_duplicate_function_tests
35/55 Test #35: curlee_cli_check_duplicate_function_tests ......   Passed    0.02 sec
      Start 36: curlee_cli_check_import_order_tests
36/55 Test #36: curlee_cli_check_import_order_tests ............   Passed    0.01 sec
      Start 37: curlee_cli_check_import_path_tests
37/55 Test #37: curlee_cli_check_import_path_tests .............   Passed    0.01 sec
      Start 38: curlee_cli_bundle_tests
38/55 Test #38: curlee_cli_bundle_tests ........................   Passed    0.04 sec
      Start 39: curlee_cli_bundle_golden_tests
39/55 Test #39: curlee_cli_bundle_golden_tests .................   Passed    0.01 sec
      Start 40: curlee_cli_fuel_tests
40/55 Test #40: curlee_cli_fuel_tests ..........................   Passed    0.02 sec
      Start 41: curlee_vm_tests
41/55 Test #41: curlee_vm_tests ................................   Passed    0.77 sec
      Start 42: curlee_vm_internal_io_unit_tests
42/55 Test #42: curlee_vm_internal_io_unit_tests ...............   Passed    0.00 sec
      Start 43: curlee_bundle_tests
43/55 Test #43: curlee_bundle_tests ............................   Passed    0.00 sec
      Start 44: curlee_interop_tests
44/55 Test #44: curlee_interop_tests ...........................   Passed    0.00 sec
      Start 45: curlee_python_runner_tests
45/55 Test #45: curlee_python_runner_tests .....................   Passed    0.04 sec
      Start 46: curlee_python_runner_json_unit_tests
46/55 Test #46: curlee_python_runner_json_unit_tests ...........   Passed    0.00 sec
      Start 47: curlee_e2e_tests
47/55 Test #47: curlee_e2e_tests ...............................   Passed    0.28 sec
      Start 48: curlee_compiler_tests
48/55 Test #48: curlee_compiler_tests ..........................   Passed    0.01 sec
      Start 49: curlee_tensor_ir_tests
49/55 Test #49: curlee_tensor_ir_tests .........................   Passed    0.00 sec
      Start 50: curlee_tensor_backend_tests
50/55 Test #50: curlee_tensor_backend_tests ....................   Passed    0.00 sec
      Start 51: curlee_verification_solver_extra_tests
51/55 Test #51: curlee_verification_solver_extra_tests .........   Passed    0.03 sec
      Start 52: curlee_verification_tests
52/55 Test #52: curlee_verification_tests ......................   Passed    0.04 sec
      Start 53: curlee_verification_predicate_lowering_tests
53/55 Test #53: curlee_verification_predicate_lowering_tests ...   Passed    0.18 sec
      Start 54: curlee_verification_checker_tests
54/55 Test #54: curlee_verification_checker_tests ..............   Passed    0.08 sec
      Start 55: curlee_verification_checker_internal_tests
55/55 Test #55: curlee_verification_checker_internal_tests .....   Passed    0.02 sec

100% tests passed, 0 tests failed out of 55

Total Test time (real) =   2.88 sec
lines: 100.0% (6132 out of 6132)
functions: 100.0% (598 out of 598)
branches: 100.0% (6012 out of 6012)

Coverage report: build/coverage/coverage.html
Coverage summary: build/coverage/coverage.txt on pull requests and fails if line/branch/function coverage drops below 100%. Also extends Preset CMake variables:

  CMAKE_BUILD_TYPE="Debug"
  CMAKE_CXX_FLAGS="-O0 -g --coverage"
  CMAKE_EXE_LINKER_FLAGS="--coverage"
  CMAKE_EXPORT_COMPILE_COMMANDS="ON"
  CMAKE_INSTALL_PREFIX:PATH="/home/joe/Projects/curlee/build/linux-debug-coverage/install"
  CMAKE_SHARED_LINKER_FLAGS="--coverage"

-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/joe/Projects/curlee/build/linux-debug-coverage
ninja: no work to do.
Test project /home/joe/Projects/curlee/build/linux-debug-coverage
      Start  1: curlee_install_smoke
 1/55 Test  #1: curlee_install_smoke ...........................   Passed    0.07 sec
      Start  2: curlee_help
 2/55 Test  #2: curlee_help ....................................   Passed    0.01 sec
      Start  3: curlee_no_args
 3/55 Test  #3: curlee_no_args .................................   Passed    0.01 sec
      Start  4: curlee_missing_file
 4/55 Test  #4: curlee_missing_file ............................   Passed    0.01 sec
      Start  5: curlee_lex_reads_file
 5/55 Test  #5: curlee_lex_reads_file ..........................   Passed    0.01 sec
      Start  6: curlee_line_map_tests
 6/55 Test  #6: curlee_line_map_tests ..........................   Passed    0.00 sec
      Start  7: curlee_source_file_tests
 7/55 Test  #7: curlee_source_file_tests .......................   Passed    0.00 sec
      Start  8: curlee_diagnostic_golden_tests
 8/55 Test  #8: curlee_diagnostic_golden_tests .................   Passed    0.00 sec
      Start  9: curlee_diag_render_tests
 9/55 Test  #9: curlee_diag_render_tests .......................   Passed    0.00 sec
      Start 10: curlee_header_smoke_tests
10/55 Test #10: curlee_header_smoke_tests ......................   Passed    0.00 sec
      Start 11: curlee_python_runner_fake_hang_smoke
11/55 Test #11: curlee_python_runner_fake_hang_smoke ...........   Passed    0.01 sec
      Start 12: curlee_python_runner_fake_spam_smoke
12/55 Test #12: curlee_python_runner_fake_spam_smoke ...........   Passed    0.01 sec
      Start 13: curlee_bwrap_fake_smoke
13/55 Test #13: curlee_bwrap_fake_smoke ........................   Passed    0.00 sec
      Start 14: curlee_bwrap_fake_exec
14/55 Test #14: curlee_bwrap_fake_exec .........................   Passed    0.00 sec
      Start 15: curlee_fake_exes_tests
15/55 Test #15: curlee_fake_exes_tests .........................   Passed    0.01 sec
      Start 16: curlee_cli_diagnostics_golden_tests
16/55 Test #16: curlee_cli_diagnostics_golden_tests ............   Passed    0.62 sec
      Start 17: curlee_lexer_tests
17/55 Test #17: curlee_lexer_tests .............................   Passed    0.00 sec
      Start 18: curlee_parser_tests
18/55 Test #18: curlee_parser_tests ............................   Passed    0.01 sec
      Start 19: curlee_lsp_hover_golden_tests
19/55 Test #19: curlee_lsp_hover_golden_tests ..................   Passed    0.11 sec
      Start 20: curlee_lsp_internal_tests
20/55 Test #20: curlee_lsp_internal_tests ......................   Passed    0.01 sec
      Start 21: curlee_fuzz_regression_tests
21/55 Test #21: curlee_fuzz_regression_tests ...................   Passed    0.00 sec
      Start 22: curlee_resolver_tests
22/55 Test #22: curlee_resolver_tests ..........................   Passed    0.01 sec
      Start 23: curlee_parser_internal_tests
23/55 Test #23: curlee_parser_internal_tests ...................   Passed    0.00 sec
      Start 24: curlee_types_tests
24/55 Test #24: curlee_types_tests .............................   Passed    0.01 sec
      Start 25: curlee_types_extra_tests
25/55 Test #25: curlee_types_extra_tests .......................   Passed    0.01 sec
      Start 26: curlee_training_data_tests
26/55 Test #26: curlee_training_data_tests .....................   Passed    0.08 sec
      Start 27: curlee_cli_fmt_tests
27/55 Test #27: curlee_cli_fmt_tests ...........................   Passed    0.09 sec
      Start 28: curlee_cli_version_tests
28/55 Test #28: curlee_cli_version_tests .......................   Passed    0.01 sec
      Start 29: curlee_cli_bad_args_tests
29/55 Test #29: curlee_cli_bad_args_tests ......................   Passed    0.01 sec
      Start 30: curlee_cli_lex_parse_error_tests
30/55 Test #30: curlee_cli_lex_parse_error_tests ...............   Passed    0.01 sec
      Start 31: curlee_cli_check_import_error_tests
31/55 Test #31: curlee_cli_check_import_error_tests ............   Passed    0.10 sec
      Start 32: curlee_cli_check_import_cycle_tests
32/55 Test #32: curlee_cli_check_import_cycle_tests ............   Passed    0.01 sec
      Start 33: curlee_cli_check_import_depth_tests
33/55 Test #33: curlee_cli_check_import_depth_tests ............   Passed    0.01 sec
      Start 34: curlee_cli_check_imported_main_tests
34/55 Test #34: curlee_cli_check_imported_main_tests ...........   Passed    0.01 sec
      Start 35: curlee_cli_check_duplicate_function_tests
35/55 Test #35: curlee_cli_check_duplicate_function_tests ......   Passed    0.02 sec
      Start 36: curlee_cli_check_import_order_tests
36/55 Test #36: curlee_cli_check_import_order_tests ............   Passed    0.01 sec
      Start 37: curlee_cli_check_import_path_tests
37/55 Test #37: curlee_cli_check_import_path_tests .............   Passed    0.01 sec
      Start 38: curlee_cli_bundle_tests
38/55 Test #38: curlee_cli_bundle_tests ........................   Passed    0.04 sec
      Start 39: curlee_cli_bundle_golden_tests
39/55 Test #39: curlee_cli_bundle_golden_tests .................   Passed    0.01 sec
      Start 40: curlee_cli_fuel_tests
40/55 Test #40: curlee_cli_fuel_tests ..........................   Passed    0.02 sec
      Start 41: curlee_vm_tests
41/55 Test #41: curlee_vm_tests ................................   Passed    0.77 sec
      Start 42: curlee_vm_internal_io_unit_tests
42/55 Test #42: curlee_vm_internal_io_unit_tests ...............   Passed    0.00 sec
      Start 43: curlee_bundle_tests
43/55 Test #43: curlee_bundle_tests ............................   Passed    0.00 sec
      Start 44: curlee_interop_tests
44/55 Test #44: curlee_interop_tests ...........................   Passed    0.00 sec
      Start 45: curlee_python_runner_tests
45/55 Test #45: curlee_python_runner_tests .....................   Passed    0.04 sec
      Start 46: curlee_python_runner_json_unit_tests
46/55 Test #46: curlee_python_runner_json_unit_tests ...........   Passed    0.00 sec
      Start 47: curlee_e2e_tests
47/55 Test #47: curlee_e2e_tests ...............................   Passed    0.37 sec
      Start 48: curlee_compiler_tests
48/55 Test #48: curlee_compiler_tests ..........................   Passed    0.01 sec
      Start 49: curlee_tensor_ir_tests
49/55 Test #49: curlee_tensor_ir_tests .........................   Passed    0.00 sec
      Start 50: curlee_tensor_backend_tests
50/55 Test #50: curlee_tensor_backend_tests ....................   Passed    0.00 sec
      Start 51: curlee_verification_solver_extra_tests
51/55 Test #51: curlee_verification_solver_extra_tests .........   Passed    0.03 sec
      Start 52: curlee_verification_tests
52/55 Test #52: curlee_verification_tests ......................   Passed    0.04 sec
      Start 53: curlee_verification_predicate_lowering_tests
53/55 Test #53: curlee_verification_predicate_lowering_tests ...   Passed    0.19 sec
      Start 54: curlee_verification_checker_tests
54/55 Test #54: curlee_verification_checker_tests ..............   Passed    0.10 sec
      Start 55: curlee_verification_checker_internal_tests
55/55 Test #55: curlee_verification_checker_internal_tests .....   Passed    0.02 sec

100% tests passed, 0 tests failed out of 55

Total Test time (real) =   2.91 sec
lines: 100.0% (6132 out of 6132)
functions: 100.0% (598 out of 598)
branches: 100.0% (6012 out of 6012)

Coverage report: build/coverage/coverage.html
Coverage summary: build/coverage/coverage.txt to optionally enforce branch/function thresholds.