### PR TITLE
Release v0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-project(curlee VERSION 0.2.1 LANGUAGES CXX)
+project(curlee VERSION 0.3.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Bumps project version to 0.3.0 for the next minor release.

Verification:
- ./scripts/coverage.sh