### PR TITLE
Issue #138: capability types (cap ...)

### DIFF
--- a/include/curlee/parser/ast.h
+++ b/include/curlee/parser/ast.h
@@ -23,6 +23,7 @@ namespace curlee::parser
 struct TypeName
 {
     curlee::source::Span span;
+    bool is_capability = false;
     std::string_view name;
 };
 

--- a/include/curlee/types/type.h
+++ b/include/curlee/types/type.h
@@ -20,6 +20,7 @@ enum class TypeKind
     Bool,
     String,
     Unit,
+    Capability,
     Struct,
     Enum,
 };
@@ -43,7 +44,7 @@ struct Type
     {
         return false;
     }
-    if (a.kind == TypeKind::Struct || a.kind == TypeKind::Enum)
+    if (a.kind == TypeKind::Capability || a.kind == TypeKind::Struct || a.kind == TypeKind::Enum)
     {
         return a.name == b.name;
     }
@@ -87,6 +88,8 @@ struct CapabilityType
         return "String";
     case TypeKind::Unit:
         return "Unit";
+    case TypeKind::Capability:
+        return "cap";
     case TypeKind::Struct:
         return "Struct";
     case TypeKind::Enum:
@@ -97,7 +100,7 @@ struct CapabilityType
 
 [[nodiscard]] constexpr std::string_view to_string(Type t)
 {
-    if (t.kind == TypeKind::Struct || t.kind == TypeKind::Enum)
+    if (t.kind == TypeKind::Capability || t.kind == TypeKind::Struct || t.kind == TypeKind::Enum)
     {
         return t.name;
     }

--- a/include/curlee/types/type_check.h
+++ b/include/curlee/types/type_check.h
@@ -27,6 +27,14 @@ struct TypeInfo
 {
     std::unordered_map<std::size_t, Type> expr_types;
 
+    struct RequiredCapability
+    {
+        std::string_view name;
+        curlee::source::Span span;
+    };
+
+    std::vector<RequiredCapability> required_capabilities;
+
     [[nodiscard]] std::optional<Type> type_of(std::size_t expr_id) const
     {
         const auto it = expr_types.find(expr_id);

--- a/src/interop/python_ffi.cpp
+++ b/src/interop/python_ffi.cpp
@@ -6,7 +6,7 @@ namespace curlee::interop
 namespace
 {
 
-constexpr std::string_view kPythonCapability = "python:ffi";
+constexpr std::string_view kPythonCapability = "python.ffi";
 
 } // namespace
 

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -821,9 +821,9 @@ VmResult VM::run(const Chunk& chunk, std::size_t fuel, const Capabilities& capab
         }
         case OpCode::Print:
         {
-            if (!capabilities.contains("io:stdout"))
+            if (!capabilities.contains("io.stdout"))
             {
-                return err_result("missing capability io:stdout", span);
+                return err_result("missing capability io.stdout", span);
             }
             auto value = pop();
             if (!value.has_value())
@@ -836,7 +836,7 @@ VmResult VM::run(const Chunk& chunk, std::size_t fuel, const Capabilities& capab
         }
         case OpCode::PythonCall:
         {
-            if (!capabilities.contains("python:ffi"))
+            if (!capabilities.contains("python.ffi"))
             {
                 return err_result("python capability required", span);
             }
@@ -845,7 +845,7 @@ VmResult VM::run(const Chunk& chunk, std::size_t fuel, const Capabilities& capab
             const std::string request =
                 "{\"protocol_version\":1,\"id\":\"vm\",\"op\":\"handshake\"}\n";
 
-            const bool use_sandbox = capabilities.contains("python:sandbox");
+            const bool use_sandbox = capabilities.contains("python.sandbox");
             ProcResult proc;
             if (use_sandbox)
             {

--- a/tests/bundle_tests.cpp
+++ b/tests/bundle_tests.cpp
@@ -68,7 +68,7 @@ int main()
 
         Bundle bundle;
         bundle.manifest.format_version = kBundleFormatVersion;
-        bundle.manifest.capabilities = {"io:stdout", "net:none"};
+        bundle.manifest.capabilities = {"io.stdout", "net:none"};
         bundle.manifest.imports = {ImportPin{.path = "stdlib.math", .hash = "deadbeef"}};
         bundle.manifest.proof = "proof-v1";
         bundle.bytecode = {0x01, 0x02, 0x03, 0x04};
@@ -324,7 +324,7 @@ int main()
                                             std::to_string(kBundleFormatVersion) + "\n" +
                                             "bytecode_hash=" + hash_bytes(empty_bytes) + "\n" +
                                             "imports=stdlib.math:deadbeef\n" +
-                                            "capabilities=,io:stdout,,net:none,\n" +
+                                            "capabilities=,io.stdout,,net:none,\n" +
                                             "proof=hello\n" + "bytecode=   \t \n");
         expect_read_ok(whitespace_b64);
         std::filesystem::remove(whitespace_b64);
@@ -416,7 +416,7 @@ int main()
         out << "CURLEE_BUNDLE_V1\n";
         out << "version=" << kBundleFormatVersion << "\n";
         out << "bytecode_hash=deadbeef\n";
-        out << "capabilities=io:stdout\n";
+        out << "capabilities=io.stdout\n";
         out << "imports=stdlib.math:bead\n";
         out << "proof=\n";
         out << "bytecode=AQIDBA==\n";
@@ -463,7 +463,7 @@ int main()
 
         Bundle bundle_1;
         bundle_1.manifest.format_version = kBundleFormatVersion;
-        bundle_1.manifest.capabilities = {"io:stdout"};
+        bundle_1.manifest.capabilities = {"io.stdout"};
         bundle_1.manifest.imports = {ImportPin{.path = "a", .hash = "b"},
                                      ImportPin{.path = "c", .hash = "d"}};
         bundle_1.bytecode = {0xFF};

--- a/tests/cli_bad_args_tests.cpp
+++ b/tests/cli_bad_args_tests.cpp
@@ -222,7 +222,7 @@ int main()
         std::string out;
         std::string err;
         const int rc = run_cli_capture(
-            {"curlee", "run", "--capability", "io:stdout", "--fuel", "0"}, out, err);
+            {"curlee", "run", "--capability", "io.stdout", "--fuel", "0"}, out, err);
         if (rc != 2)
         {
             fail("expected usage exit code for missing run file (with --capability)");
@@ -247,7 +247,7 @@ int main()
         std::string out;
         std::string err;
         const int rc =
-            run_cli_capture({"curlee", "run", "--cap=io:stdout", "--fuel", "0"}, out, err);
+            run_cli_capture({"curlee", "run", "--cap=io.stdout", "--fuel", "0"}, out, err);
         if (rc != 2)
         {
             fail("expected usage exit code for missing run file (with --cap=)");
@@ -457,7 +457,7 @@ int main()
         fs::remove(bundle_path);
 
         curlee::bundle::Bundle bundle;
-        bundle.manifest.capabilities = {"io:stdout"};
+        bundle.manifest.capabilities = {"io.stdout"};
         bundle.manifest.imports = {};
         bundle.manifest.proof = std::nullopt;
         bundle.bytecode = {0x01, 0x02, 0x03, 0x04};

--- a/tests/cli_bundle/current_v1.bundle
+++ b/tests/cli_bundle/current_v1.bundle
@@ -1,7 +1,7 @@
 CURLEE_BUNDLE
 format_version=1
 bytecode_hash=be7a5e775165785d
-capabilities=io:stdout,net:none
+capabilities=io.stdout,net:none
 imports=stdlib.math:deadbeef
 proof=proof-v1
 bytecode=AQIDBA==

--- a/tests/cli_bundle/current_v1.stdout.golden
+++ b/tests/cli_bundle/current_v1.stdout.golden
@@ -1,6 +1,6 @@
 curlee bundle info:
 format_version: 1
 bytecode_hash: be7a5e775165785d
-capabilities: io:stdout,net:none
+capabilities: io.stdout,net:none
 imports: stdlib.math:deadbeef
 proof: present

--- a/tests/cli_bundle_tests.cpp
+++ b/tests/cli_bundle_tests.cpp
@@ -97,7 +97,7 @@ int main()
     fs::remove(missing_path);
 
     Bundle bundle;
-    bundle.manifest.capabilities = {"io:stdout", "net:none"};
+    bundle.manifest.capabilities = {"io.stdout", "net:none"};
     bundle.manifest.imports = {ImportPin{.path = "stdlib.math", .hash = "deadbeef"}};
     bundle.manifest.proof = "proof-v1";
     bundle.bytecode = curlee::vm::encode_chunk(make_return_int_chunk(0));
@@ -160,7 +160,7 @@ int main()
                                      "bytecode_hash: " +
                                      expected_hash +
                                      "\n"
-                                     "capabilities: io:stdout,net:none\n"
+                                     "capabilities: io.stdout,net:none\n"
                                      "imports: stdlib.math:deadbeef\n"
                                      "proof: present\n";
 
@@ -173,7 +173,7 @@ int main()
     // bundle info: multi-import pins + proof absence are formatted deterministically.
     {
         Bundle bundle;
-        bundle.manifest.capabilities = {"io:stdout", "net:none"};
+        bundle.manifest.capabilities = {"io.stdout", "net:none"};
         bundle.manifest.imports = {ImportPin{.path = "stdlib.math", .hash = "deadbeef"},
                                    ImportPin{.path = "stdlib.io", .hash = "bead"}};
         bundle.manifest.proof = std::nullopt;
@@ -203,7 +203,7 @@ int main()
                                      "bytecode_hash: " +
                                      expected_hash +
                                      "\n"
-                                     "capabilities: io:stdout,net:none\n"
+                                     "capabilities: io.stdout,net:none\n"
                                      "imports: stdlib.math:deadbeef,stdlib.io:bead\n"
                                      "proof: none\n";
 
@@ -232,14 +232,14 @@ int main()
     // with manifest fields should fail verification.
     {
         std::string contents = slurp(ok_path);
-        const std::string needle = "capabilities=io:stdout,net:none\n";
+        const std::string needle = "capabilities=io.stdout,net:none\n";
         const auto pos = contents.find(needle);
         if (pos == std::string::npos)
         {
             fail("expected bundle to contain capabilities line for tamper test");
         }
 
-        contents.replace(pos, needle.size(), "capabilities=io:stdout,net:all\n");
+        contents.replace(pos, needle.size(), "capabilities=io.stdout,net:all\n");
         write_all(ok_path, contents);
 
         std::string out;
@@ -284,7 +284,7 @@ int main()
         out << "CURLEE_BUNDLE_V1\n";
         out << "version=" << kBundleFormatVersion << "\n";
         out << "bytecode_hash=deadbeef\n";
-        out << "capabilities=io:stdout\n";
+        out << "capabilities=io.stdout\n";
         out << "imports=stdlib.math:bead\n";
         out << "proof=\n";
         out << "bytecode=AQIDBA==\n";
@@ -417,7 +417,7 @@ int main()
         }
 
         Bundle bundle;
-        bundle.manifest.capabilities = {"python:ffi"};
+        bundle.manifest.capabilities = {"python.ffi"};
         bundle.manifest.imports = {};
         bundle.bytecode = curlee::vm::encode_chunk(make_return_int_chunk(0));
 
@@ -437,7 +437,7 @@ int main()
             {
                 fail("expected run to fail when bundle capability is not granted");
             }
-            if (err.find("missing capability required by bundle: python:ffi") == std::string::npos)
+            if (err.find("missing capability required by bundle: python.ffi") == std::string::npos)
             {
                 fail("expected stderr to mention missing capability required by bundle");
             }
@@ -447,7 +447,7 @@ int main()
         {
             std::string out;
             std::string err;
-            const int rc = run_cli({"curlee", "run", "--cap", "python:ffi", "--bundle",
+            const int rc = run_cli({"curlee", "run", "--cap", "python.ffi", "--bundle",
                                     bundle_path.string(), entry.string()},
                                    out, err);
             if (rc != 0)

--- a/tests/cli_diagnostics/run_python_ffi_missing_cap.stderr.golden
+++ b/tests/cli_diagnostics/run_python_ffi_missing_cap.stderr.golden
@@ -1,4 +1,5 @@
-tests/fixtures/run_python_ffi.curlee:2:12: error: python capability required
+tests/fixtures/run_python_ffi.curlee:2:12: error: capability not granted: python.ffi
   |
   |   unsafe { python_ffi.call(); }
   |            ^^^^^^^^^^^^^^^^^
+note: grant it with: curlee run --cap python.ffi <file.curlee>

--- a/tests/cli_diagnostics_golden_tests.cpp
+++ b/tests/cli_diagnostics_golden_tests.cpp
@@ -473,7 +473,7 @@ static bool run_run_success_with_cap_case(const fs::path& out_golden_path,
 
     const std::string rel_path = "tests/fixtures/run_success.curlee";
 
-    std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python:ffi", rel_path};
+    std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python.ffi", rel_path};
     std::vector<char*> argv;
     argv.reserve(argv_storage.size());
     for (auto& s : argv_storage)
@@ -965,7 +965,7 @@ int main(int argc, char** argv)
 
         {
             const std::string rel_path = "tests/fixtures/run_python_ffi.curlee";
-            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python:ffi",
+            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python.ffi",
                                                            rel_path};
             if (!run_run_python_ffi_case(argv_storage, run_python_ffi_not_implemented_out_golden,
                                          run_python_ffi_not_implemented_err_golden,
@@ -980,7 +980,7 @@ int main(int argc, char** argv)
             (void)setenv("CURLEE_PYTHON_RUNNER", fake_runner_error.c_str(), 1);
 
             const std::string rel_path = "tests/fixtures/run_python_ffi.curlee";
-            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python:ffi",
+            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python.ffi",
                                                            rel_path};
             if (!run_run_python_ffi_case(argv_storage, run_python_ffi_runner_error_out_golden,
                                          run_python_ffi_runner_error_err_golden,
@@ -997,7 +997,7 @@ int main(int argc, char** argv)
             (void)setenv("CURLEE_PYTHON_RUNNER", fake_runner_hang.c_str(), 1);
 
             const std::string rel_path = "tests/fixtures/run_python_ffi.curlee";
-            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python:ffi",
+            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python.ffi",
                                                            rel_path};
             if (!run_run_python_ffi_case(argv_storage, run_python_ffi_runner_timeout_out_golden,
                                          run_python_ffi_runner_timeout_err_golden,
@@ -1014,7 +1014,7 @@ int main(int argc, char** argv)
             (void)setenv("CURLEE_PYTHON_RUNNER", fake_runner_spam.c_str(), 1);
 
             const std::string rel_path = "tests/fixtures/run_python_ffi.curlee";
-            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python:ffi",
+            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python.ffi",
                                                            rel_path};
             if (!run_run_python_ffi_case(argv_storage,
                                          run_python_ffi_runner_output_limit_out_golden,
@@ -1033,7 +1033,7 @@ int main(int argc, char** argv)
             (void)setenv("CURLEE_PYTHON_RUNNER", fake_runner_env_check.c_str(), 1);
 
             const std::string rel_path = "tests/fixtures/run_python_ffi.curlee";
-            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python:ffi",
+            const std::vector<std::string> argv_storage = {"curlee", "run", "--cap", "python.ffi",
                                                            rel_path};
             if (!run_run_python_ffi_case(argv_storage,
                                          run_python_ffi_runner_env_sanitized_out_golden,
@@ -1059,7 +1059,7 @@ int main(int argc, char** argv)
             // Without the sandbox capability, this should fail.
             {
                 const std::vector<std::string> argv_storage = {"curlee", "run", "--cap",
-                                                               "python:ffi", rel_path};
+                                                               "python.ffi", rel_path};
                 if (!run_run_python_ffi_case(argv_storage,
                                              run_python_ffi_sandbox_required_out_golden,
                                              run_python_ffi_sandbox_required_err_golden,
@@ -1072,7 +1072,7 @@ int main(int argc, char** argv)
             // With the sandbox capability, the fake bwrap wrapper makes the runner succeed.
             {
                 const std::vector<std::string> argv_storage = {
-                    "curlee", "run", "--cap", "python:ffi", "--cap", "python:sandbox", rel_path};
+                    "curlee", "run", "--cap", "python.ffi", "--cap", "python.sandbox", rel_path};
                 if (!run_run_python_ffi_case(argv_storage, run_python_ffi_sandboxed_out_golden,
                                              run_python_ffi_sandboxed_err_golden,
                                              "run-python-ffi-sandboxed", 0))
@@ -1089,7 +1089,7 @@ int main(int argc, char** argv)
                 (void)setenv("CURLEE_BWRAP", missing_bwrap.c_str(), 1);
 
                 const std::vector<std::string> argv_storage = {
-                    "curlee", "run", "--cap", "python:ffi", "--cap", "python:sandbox", rel_path};
+                    "curlee", "run", "--cap", "python.ffi", "--cap", "python.sandbox", rel_path};
                 if (!run_run_python_ffi_case(argv_storage,
                                              run_python_ffi_sandbox_exec_failed_out_golden,
                                              run_python_ffi_sandbox_exec_failed_err_golden,

--- a/tests/fixtures/run_python_ffi.curlee
+++ b/tests/fixtures/run_python_ffi.curlee
@@ -1,4 +1,4 @@
-fn main() -> Int {
+fn main(p: cap python.ffi) -> Int {
   unsafe { python_ffi.call(); }
   return 0;
 }

--- a/tests/interop_tests.cpp
+++ b/tests/interop_tests.cpp
@@ -15,7 +15,7 @@ int main()
 
     {
         curlee::runtime::Capabilities caps;
-        caps.insert("io:stdout");
+        caps.insert("io.stdout");
 
         const auto res = call_python(caps, "math", "sqrt", {"4"});
         if (!std::holds_alternative<PythonFfiError>(res))
@@ -31,7 +31,7 @@ int main()
 
     {
         curlee::runtime::Capabilities caps;
-        caps.insert("python:ffi");
+        caps.insert("python.ffi");
 
         const auto res = call_python(caps, "math", "sqrt", {"4"});
         if (!std::holds_alternative<PythonFfiError>(res))

--- a/tests/lsp_internal_tests.cpp
+++ b/tests/lsp_internal_tests.cpp
@@ -588,7 +588,7 @@ int main()
             "enum E { V; } "
             "fn foo(x: Int where true) -> Int [ requires true; requires true; ] { return 0; } "
             "fn bar() -> Int { return 0; } "
-            "fn main() -> Int { let e: E = E::V(); let z: Int = foo(0); unsafe { "
+            "fn main(p: cap python.ffi) -> Int { let e: E = E::V(); let z: Int = foo(0); unsafe { "
             "python_ffi.call(); } return bar(); }";
         const std::string did_change_ok =
             std::string("{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/"

--- a/tests/verification_checker_tests.cpp
+++ b/tests/verification_checker_tests.cpp
@@ -586,7 +586,7 @@ int main()
 
     {
         // python_ffi.call(...) should not be treated as a verifier-checked call.
-        const std::string source = "fn main() -> Int {\n"
+        const std::string source = "fn main(p: cap python.ffi) -> Int {\n"
                                    "  unsafe { python_ffi.call(); }\n"
                                    "  return 0;\n"
                                    "}\n";

--- a/tests/vm_internal_io_unit_tests.cpp
+++ b/tests/vm_internal_io_unit_tests.cpp
@@ -222,9 +222,9 @@ static void vm_should_fail_print_missing_capability()
     chunk.emit(OpCode::Return);
     VM vm;
     const auto res = vm.run(chunk);
-    if (res.ok || res.error != "missing capability io:stdout")
+    if (res.ok || res.error != "missing capability io.stdout")
     {
-        fail("expected missing capability io:stdout");
+        fail("expected missing capability io.stdout");
     }
 }
 

--- a/tests/vm_tests.cpp
+++ b/tests/vm_tests.cpp
@@ -406,9 +406,9 @@ int main(int argc, char** argv)
 
         // Denied by default (no capabilities).
         const auto denied = vm.run(chunk);
-        if (denied.ok || denied.error != "missing capability io:stdout")
+        if (denied.ok || denied.error != "missing capability io.stdout")
         {
-            fail("expected print to be denied without io:stdout capability");
+            fail("expected print to be denied without io.stdout capability");
         }
         if (!denied.error_span.has_value() || denied.error_span->start != span.start ||
             denied.error_span->end != span.end)
@@ -418,11 +418,11 @@ int main(int argc, char** argv)
 
         // Allowed when capability present.
         VM::Capabilities caps;
-        caps.insert("io:stdout");
+        caps.insert("io.stdout");
         const auto allowed = vm.run(chunk, caps);
         if (!allowed.ok || !(allowed.value == Value::int_v(1)))
         {
-            fail("expected print to succeed with io:stdout capability");
+            fail("expected print to succeed with io.stdout capability");
         }
     }
 
@@ -1107,7 +1107,7 @@ int main(int argc, char** argv)
 
         VM vm;
         VM::Capabilities caps;
-        caps.insert("io:stdout");
+        caps.insert("io.stdout");
         const auto res = vm.run(chunk, caps);
         if (!res.ok || res.value.kind != ValueKind::Unit)
         {
@@ -1465,7 +1465,7 @@ int main(int argc, char** argv)
 
         VM vm;
         VM::Capabilities caps;
-        caps.insert("io:stdout");
+        caps.insert("io.stdout");
         const auto res = vm.run(chunk, caps);
         if (res.ok || res.error != "stack underflow")
         {
@@ -1504,7 +1504,7 @@ int main(int argc, char** argv)
 
         VM vm;
         VM::Capabilities caps;
-        caps.insert("python:ffi");
+        caps.insert("python.ffi");
 
         runner.set("/bin/true");
 
@@ -1568,7 +1568,7 @@ int main(int argc, char** argv)
 
         VM vm;
         VM::Capabilities caps;
-        caps.insert("python:ffi");
+        caps.insert("python.ffi");
 
         // Non-sandbox exec failure path.
         (void)setenv("CURLEE_PYTHON_RUNNER", "/no/such/curlee_python_runner_missing", 1);
@@ -1584,7 +1584,7 @@ int main(int argc, char** argv)
         // and execve fails deterministically (no PATH search).
         {
             VM::Capabilities sandbox_caps = caps;
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.sandbox");
 
             (void)unsetenv("CURLEE_BWRAP");
             (void)setenv("CURLEE_PYTHON_RUNNER", runner_plain_fail.c_str(), 1);
@@ -1600,7 +1600,7 @@ int main(int argc, char** argv)
         // `env != nullptr && *env != '\0'`.
         {
             VM::Capabilities sandbox_caps = caps;
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.sandbox");
 
             (void)setenv("CURLEE_BWRAP", "", 1);
             (void)setenv("CURLEE_PYTHON_RUNNER", runner_plain_fail.c_str(), 1);
@@ -1616,7 +1616,7 @@ int main(int argc, char** argv)
         // the fallback path, but bwrap exec still fails so the runner is never executed.
         {
             VM::Capabilities sandbox_caps = caps;
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.sandbox");
 
             (void)unsetenv("CURLEE_PYTHON_RUNNER");
             (void)unsetenv("CURLEE_BWRAP");
@@ -1632,7 +1632,7 @@ int main(int argc, char** argv)
         // `env != nullptr && *env != '\0'`.
         {
             VM::Capabilities sandbox_caps = caps;
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.sandbox");
 
             (void)setenv("CURLEE_PYTHON_RUNNER", "", 1);
             (void)unsetenv("CURLEE_BWRAP");
@@ -1689,7 +1689,7 @@ int main(int argc, char** argv)
             RenameGuard guard(from, to);
 
             VM::Capabilities sandbox_caps = caps;
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.sandbox");
             (void)unsetenv("CURLEE_PYTHON_RUNNER");
             (void)unsetenv("CURLEE_BWRAP");
 
@@ -1883,8 +1883,8 @@ int main(int argc, char** argv)
         (void)setenv("CURLEE_BWRAP", bwrap_fake.c_str(), 1);
         {
             VM::Capabilities sandbox_caps;
-            sandbox_caps.insert("python:ffi");
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.ffi");
+            sandbox_caps.insert("python.sandbox");
             const auto res = vm.run(chunk, sandbox_caps);
             if (!res.ok || !(res.value == Value::unit_v()))
             {
@@ -1897,8 +1897,8 @@ int main(int argc, char** argv)
         (void)setenv("CURLEE_BWRAP", bwrap_fake.c_str(), 1);
         {
             VM::Capabilities sandbox_caps;
-            sandbox_caps.insert("python:ffi");
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.ffi");
+            sandbox_caps.insert("python.sandbox");
             const auto res = vm.run(chunk, sandbox_caps);
             if (res.ok || res.error != "python sandbox failed")
             {
@@ -1911,8 +1911,8 @@ int main(int argc, char** argv)
         (void)setenv("CURLEE_BWRAP", "/no/such/bwrap", 1);
         {
             VM::Capabilities sandbox_caps;
-            sandbox_caps.insert("python:ffi");
-            sandbox_caps.insert("python:sandbox");
+            sandbox_caps.insert("python.ffi");
+            sandbox_caps.insert("python.sandbox");
             const auto res = vm.run(chunk, sandbox_caps);
             if (res.ok || res.error != "python sandbox exec failed")
             {


### PR DESCRIPTION
Fixes #138.

Summary:
- Add capability types: cap <qualified> (e.g. cap io.stdout, cap python.ffi).
- Require a capability-typed value in scope for effectful ops (print, python_ffi.call).
- curlee run checks required vs granted host capabilities (via --cap) and errors early.
- Normalize capability identifiers to dotted form (io.stdout, python.ffi, python.sandbox).

Verification:
- ./scripts/coverage.sh --fail-under 100 --fail-under-branch 100 --fail-under-function 100
