### PR TITLE
Docs: reconcile README with current MVP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,15 @@ target_include_directories(curlee_header_smoke_tests PRIVATE include)
 
 add_test(NAME curlee_header_smoke_tests COMMAND curlee_header_smoke_tests)
 
+add_executable(curlee_readme_claims_tests
+  tests/readme_claims_tests.cpp
+)
+
+add_test(
+  NAME curlee_readme_claims_tests
+  COMMAND curlee_readme_claims_tests ${CMAKE_SOURCE_DIR}/README.md
+)
+
 add_executable(curlee_chunk_codec_tests
   tests/chunk_codec_tests.cpp
   src/vm/chunk_codec.cpp

--- a/README.md
+++ b/README.md
@@ -114,11 +114,17 @@ Curlee currently supports two useful workflows:
 
 The runnable subset is intentionally small:
 
-- Expressions: `Int` / `Bool` literals, names, `+`, grouping.
-- Statements: `let`, `return`, `if/else`, `while`.
-- Calls: simple **no-arg** calls to a named function.
+The supported fragment evolves quickly; the **wiki is the source of truth**:
 
-Out of scope (for now): strings, general unary/binary ops, function parameters, modules/import execution.
+- Supported fragment + runnable subset: https://github.com/w4ffl35/curlee/wiki/Stability-and-Supported-Fragment
+- Syntax reference: https://github.com/w4ffl35/curlee/wiki/Language-Syntax
+- Modules/imports: https://github.com/w4ffl35/curlee/wiki/Modules-and-Imports
+- Execution model (fuel, capabilities, interop): https://github.com/w4ffl35/curlee/wiki/Running-Programs
+
+At a high level:
+
+- `curlee check` supports imports (including aliasing and module-qualified calls) and function parameters, and verifies contracts within the MVP scope.
+- `curlee run` executes a conservative, deterministic subset on the VM after successful verification (see the wiki for the exact runnable subset).
 
 ---
 

--- a/tests/readme_claims_tests.cpp
+++ b/tests/readme_claims_tests.cpp
@@ -1,0 +1,64 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+static std::string slurp(const std::filesystem::path& path)
+{
+    std::ifstream in(path, std::ios::binary);
+    if (!in)
+    {
+        throw std::runtime_error("failed to open file: " + path.string());
+    }
+
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
+
+static void expect_contains(const std::string& haystack, const std::string& needle,
+                            const char* what)
+{
+    if (haystack.find(needle) == std::string::npos)
+    {
+        std::cerr << "FAIL: missing " << what << " (expected to contain: '" << needle << "')\n";
+        std::exit(1);
+    }
+}
+
+static void expect_not_contains(const std::string& haystack, const std::string& needle,
+                                const char* what)
+{
+    if (haystack.find(needle) != std::string::npos)
+    {
+        std::cerr << "FAIL: contains stale " << what << " (unexpected: '" << needle << "')\n";
+        std::exit(1);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 2)
+    {
+        std::cerr << "usage: curlee_readme_claims_tests <path-to-README.md>\n";
+        return 2;
+    }
+
+    const std::filesystem::path readme_path = argv[1];
+    const std::string readme = slurp(readme_path);
+
+    // Positive, stable anchors.
+    expect_contains(readme, "No proof, no run.", "core motto");
+    expect_contains(readme, "https://github.com/w4ffl35/curlee/wiki", "wiki link");
+    expect_contains(readme, "Stability-and-Supported-Fragment", "supported fragment link");
+
+    // Guard against a few known-stale claims.
+    expect_not_contains(readme, "Calls: simple **no-arg** calls", "no-arg calls limitation");
+    expect_not_contains(readme, "Out of scope (for now): strings", "out-of-scope list");
+    expect_not_contains(readme, "modules/import execution", "imports not supported claim");
+
+    std::cout << "OK\n";
+    return 0;
+}


### PR DESCRIPTION
Closes #136.

Align README with implemented MVP by removing stale limitations and pointing to the wiki as the source of truth. Add a small CTest (readme claims) to prevent reintroducing a few known-stale README statements.

Verification:
- cmake --preset linux-debug
- cmake --build --preset linux-debug
- ctest --preset linux-debug --output-on-failure
- ./scripts/coverage.sh