### PR TITLE
Front-end support for Phys<T>: physical memory type, phys() literal, and gated read/write (issue #252)

### DIFF
--- a/include/curlee/lexer/token.h
+++ b/include/curlee/lexer/token.h
@@ -19,6 +19,10 @@ enum class TokenKind
 
     Identifier,
     IntLiteral,
+    // Physical address literal: hex (0x...) or underscore-separated decimal/hex form,
+    // only valid inside `phys<U>(...)`. Kept distinct from IntLiteral so generic
+    // expression consumers (emitter, verifier) never see non-decimal lexemes.
+    PhysAddrLiteral,
     StringLiteral,
 
     // Keywords
@@ -99,6 +103,8 @@ struct Token
         return "identifier";
     case TokenKind::IntLiteral:
         return "int";
+    case TokenKind::PhysAddrLiteral:
+        return "phys_addr";
     case TokenKind::StringLiteral:
         return "string";
 

--- a/include/curlee/lexer/token.h
+++ b/include/curlee/lexer/token.h
@@ -40,6 +40,7 @@ enum class TokenKind
     KwCap,
     KwImport,
     KwAs,
+    KwPhys,
 
     KwStruct,
     KwEnum,
@@ -134,6 +135,8 @@ struct Token
         return "kw_import";
     case TokenKind::KwAs:
         return "kw_as";
+    case TokenKind::KwPhys:
+        return "kw_phys";
 
     case TokenKind::KwStruct:
         return "kw_struct";

--- a/include/curlee/parser/ast.h
+++ b/include/curlee/parser/ast.h
@@ -164,6 +164,28 @@ struct GroupExpr
     std::unique_ptr<Expr> inner;
 };
 
+/** @brief Physical memory address literal expression: `phys<U>(literal)`. */
+struct PhysExpr
+{
+    // Element kind as spelled in source (e.g. "U32").
+    std::string_view element_kind;
+    // The address literal lexeme (decimal or hex, underscores preserved).
+    std::string_view lexeme;
+};
+
+/** @brief Typed physical memory read: `phys_value.read()`. */
+struct PhysReadExpr
+{
+    std::unique_ptr<Expr> base;
+};
+
+/** @brief Typed physical memory write: `phys_value.write(v)`. */
+struct PhysWriteExpr
+{
+    std::unique_ptr<Expr> base;
+    std::unique_ptr<Expr> value;
+};
+
 /**
  * @brief A general expression node with id, span and variant payload.
  */
@@ -172,7 +194,8 @@ struct Expr
     std::size_t id = 0;
     curlee::source::Span span;
     std::variant<IntExpr, BoolExpr, StringExpr, NameExpr, UnaryExpr, BinaryExpr, CallExpr,
-                 MemberExpr, GroupExpr, ScopedNameExpr, StructLiteralExpr>
+                 MemberExpr, GroupExpr, ScopedNameExpr, StructLiteralExpr, PhysExpr,
+                 PhysReadExpr, PhysWriteExpr>
         node;
 };
 

--- a/include/curlee/types/type.h
+++ b/include/curlee/types/type.h
@@ -199,4 +199,38 @@ struct CapabilityType
     return std::nullopt;
 }
 
+/**
+ * @brief Resolve a Phys element-kind name ("U8", "U16", "U32", "U64") to a TypeKind.
+ *
+ * Returns std::nullopt for any other name. Single source of truth for the set of
+ * element kinds supported by `Phys<T>`.
+ */
+[[nodiscard]] inline std::optional<TypeKind> phys_element_kind_from_name(std::string_view name)
+{
+    if (name == "U8")
+    {
+        return TypeKind::U8;
+    }
+    if (name == "U16")
+    {
+        return TypeKind::U16;
+    }
+    if (name == "U32")
+    {
+        return TypeKind::U32;
+    }
+    if (name == "U64")
+    {
+        return TypeKind::U64;
+    }
+    return std::nullopt;
+}
+
+/** @brief True if the kind is one of the supported Phys element kinds (U8/U16/U32/U64). */
+[[nodiscard]] constexpr bool is_phys_element_kind(TypeKind kind)
+{
+    return kind == TypeKind::U8 || kind == TypeKind::U16 || kind == TypeKind::U32 ||
+           kind == TypeKind::U64;
+}
+
 } // namespace curlee::types

--- a/include/curlee/types/type.h
+++ b/include/curlee/types/type.h
@@ -26,6 +26,15 @@ enum class TypeKind
     Set,
     Struct,
     Enum,
+
+    // Unsigned fixed-width integer types (Phys element kinds).
+    U8,
+    U16,
+    U32,
+    U64,
+
+    // Physical memory pointer type (element kind stored in element_kind/element_name).
+    Phys,
 };
 
 /**
@@ -59,6 +68,10 @@ struct Type
         return a.element_kind == b.element_kind && a.element_name == b.element_name;
     }
     if (a.kind == TypeKind::Set)
+    {
+        return a.element_kind == b.element_kind && a.element_name == b.element_name;
+    }
+    if (a.kind == TypeKind::Phys)
     {
         return a.element_kind == b.element_kind && a.element_name == b.element_name;
     }
@@ -112,6 +125,16 @@ struct CapabilityType
         return "Struct";
     case TypeKind::Enum:
         return "Enum";
+    case TypeKind::U8:
+        return "U8";
+    case TypeKind::U16:
+        return "U16";
+    case TypeKind::U32:
+        return "U32";
+    case TypeKind::U64:
+        return "U64";
+    case TypeKind::Phys:
+        return "Phys";
     }
     return "<unknown>";
 }
@@ -129,6 +152,11 @@ struct CapabilityType
     if (t.kind == TypeKind::Set)
     {
         return "Set";
+    }
+    if (t.kind == TypeKind::Phys)
+    {
+        // Phys<U32> style display.
+        return "Phys";
     }
     return to_string(t.kind);
 }
@@ -151,6 +179,22 @@ struct CapabilityType
     if (name == "Unit")
     {
         return Type{.kind = TypeKind::Unit};
+    }
+    if (name == "U8")
+    {
+        return Type{.kind = TypeKind::U8};
+    }
+    if (name == "U16")
+    {
+        return Type{.kind = TypeKind::U16};
+    }
+    if (name == "U32")
+    {
+        return Type{.kind = TypeKind::U32};
+    }
+    if (name == "U64")
+    {
+        return Type{.kind = TypeKind::U64};
     }
     return std::nullopt;
 }

--- a/src/compiler/emitter.cpp
+++ b/src/compiler/emitter.cpp
@@ -1273,6 +1273,21 @@ class Emitter
     }
 
     void emit_expr_node(const curlee::parser::GroupExpr& expr, Span) { emit_expr(*expr.inner); }
+
+    void emit_expr_node(const curlee::parser::PhysExpr&, Span span)
+    {
+        diags_.push_back(error_at(span, "Phys is freestanding-only and not supported in the VM"));
+    }
+
+    void emit_expr_node(const curlee::parser::PhysReadExpr&, Span span)
+    {
+        diags_.push_back(error_at(span, "Phys is freestanding-only and not supported in the VM"));
+    }
+
+    void emit_expr_node(const curlee::parser::PhysWriteExpr&, Span span)
+    {
+        diags_.push_back(error_at(span, "Phys is freestanding-only and not supported in the VM"));
+    }
 };
 
 } // namespace

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -52,9 +52,28 @@ class Lexer
             if (std::isdigit(static_cast<unsigned char>(c)) != 0)
             {
                 advance();
-                while (!is_at_end() && (std::isdigit(static_cast<unsigned char>(peek())) != 0))
+                // Hex literal: 0x followed by hex digits.
+                bool is_hex = false;
+                if (c == '0' && (peek() == 'x' || peek() == 'X'))
                 {
+                    is_hex = true;
                     advance();
+                    if (is_at_end() || std::isxdigit(static_cast<unsigned char>(peek())) == 0)
+                    {
+                        return make_error(start, pos_, "invalid hex literal");
+                    }
+                }
+                while (!is_at_end())
+                {
+                    const char ch = peek();
+                    if (std::isdigit(static_cast<unsigned char>(ch)) != 0 ||
+                        (is_hex && (std::isxdigit(static_cast<unsigned char>(ch)) != 0)) ||
+                        ch == '_')
+                    {
+                        advance();
+                        continue;
+                    }
+                    break;
                 }
                 tokens.push_back(make_token(TokenKind::IntLiteral, start, pos_));
                 continue;
@@ -323,6 +342,10 @@ class Lexer
         if (lexeme == "match")
         {
             return TokenKind::KwMatch;
+        }
+        if (lexeme == "phys")
+        {
+            return TokenKind::KwPhys;
         }
         return TokenKind::Identifier;
     }

--- a/src/lexer/lexer.cpp
+++ b/src/lexer/lexer.cpp
@@ -52,11 +52,13 @@ class Lexer
             if (std::isdigit(static_cast<unsigned char>(c)) != 0)
             {
                 advance();
-                // Hex literal: 0x followed by hex digits.
-                bool is_hex = false;
+                // Physical-address literals may be hex (0x...) or underscore-separated
+                // (e.g. 0xFD00_0000). They are lexed as a distinct token kind so generic
+                // expression consumers (emitter, verifier) never see non-decimal lexemes.
+                bool phys_addr_form = false;
                 if (c == '0' && (peek() == 'x' || peek() == 'X'))
                 {
-                    is_hex = true;
+                    phys_addr_form = true;
                     advance();
                     if (is_at_end() || std::isxdigit(static_cast<unsigned char>(peek())) == 0)
                     {
@@ -66,16 +68,25 @@ class Lexer
                 while (!is_at_end())
                 {
                     const char ch = peek();
-                    if (std::isdigit(static_cast<unsigned char>(ch)) != 0 ||
-                        (is_hex && (std::isxdigit(static_cast<unsigned char>(ch)) != 0)) ||
-                        ch == '_')
+                    const bool is_dec = std::isdigit(static_cast<unsigned char>(ch)) != 0;
+                    const bool is_hex = phys_addr_form &&
+                                        std::isxdigit(static_cast<unsigned char>(ch)) != 0;
+                    if (ch == '_')
+                    {
+                        phys_addr_form = true;
+                        advance();
+                        continue;
+                    }
+                    if (is_dec || is_hex)
                     {
                         advance();
                         continue;
                     }
                     break;
                 }
-                tokens.push_back(make_token(TokenKind::IntLiteral, start, pos_));
+                tokens.push_back(make_token(phys_addr_form ? TokenKind::PhysAddrLiteral
+                                                           : TokenKind::IntLiteral,
+                                            start, pos_));
                 continue;
             }
 

--- a/src/lsp/lsp.cpp
+++ b/src/lsp/lsp.cpp
@@ -920,6 +920,24 @@ const curlee::parser::Expr* find_expr_at(const curlee::parser::Expr& expr, std::
             best = find_expr_at(*member->base, offset, best);
         }
     }
+    else if (const auto* phys_read = std::get_if<curlee::parser::PhysReadExpr>(&expr.node))
+    {
+        if (phys_read->base)
+        {
+            best = find_expr_at(*phys_read->base, offset, best);
+        }
+    }
+    else if (const auto* phys_write = std::get_if<curlee::parser::PhysWriteExpr>(&expr.node))
+    {
+        if (phys_write->base)
+        {
+            best = find_expr_at(*phys_write->base, offset, best);
+        }
+        if (phys_write->value)
+        {
+            best = find_expr_at(*phys_write->value, offset, best);
+        }
+    }
     else if (const auto* group = std::get_if<curlee::parser::GroupExpr>(&expr.node))
     {
         if (group->inner)
@@ -977,6 +995,24 @@ const curlee::parser::Expr* find_call_expr_at(const curlee::parser::Expr& expr, 
         if (member->base)
         {
             best = find_call_expr_at(*member->base, offset, best);
+        }
+    }
+    else if (const auto* phys_read = std::get_if<curlee::parser::PhysReadExpr>(&expr.node))
+    {
+        if (phys_read->base)
+        {
+            best = find_call_expr_at(*phys_read->base, offset, best);
+        }
+    }
+    else if (const auto* phys_write = std::get_if<curlee::parser::PhysWriteExpr>(&expr.node))
+    {
+        if (phys_write->base)
+        {
+            best = find_call_expr_at(*phys_write->base, offset, best);
+        }
+        if (phys_write->value)
+        {
+            best = find_call_expr_at(*phys_write->value, offset, best);
         }
     }
     else if (const auto* group = std::get_if<curlee::parser::GroupExpr>(&expr.node))

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1742,12 +1742,24 @@ class Parser
                 if (member.lexeme == "write" && check(TokenKind::LParen))
                 {
                     advance(); // consume '('
-                    auto value_res = parse_expr();
-                    if (std::holds_alternative<curlee::diag::Diagnostic>(value_res))
+                    Expr value;
+                    if (check(TokenKind::PhysAddrLiteral))
                     {
-                        return std::get<curlee::diag::Diagnostic>(std::move(value_res));
+                        // Hex/underscore constant: only meaningful as a phys write value,
+                        // so it is consumed here and wrapped as a constant Int expression.
+                        const Token lit = advance();
+                        value.span = lit.span;
+                        value.node = curlee::parser::IntExpr{.lexeme = lit.lexeme};
                     }
-                    Expr value = std::get<Expr>(std::move(value_res));
+                    else
+                    {
+                        auto value_res = parse_expr();
+                        if (std::holds_alternative<curlee::diag::Diagnostic>(value_res))
+                        {
+                            return std::get<curlee::diag::Diagnostic>(std::move(value_res));
+                        }
+                        value = std::get<Expr>(std::move(value_res));
+                    }
                     if (auto err = consume(TokenKind::RParen, "expected ')' after write(...)");
                         err.has_value())
                     {
@@ -1980,7 +1992,9 @@ class Parser
             {
                 return *err;
             }
-            if (!check(TokenKind::IntLiteral))
+            // The address must be a compile-time literal: decimal (IntLiteral) or
+            // hex/underscore form (PhysAddrLiteral). Both are constant-only.
+            if (!check(TokenKind::IntLiteral) && !check(TokenKind::PhysAddrLiteral))
             {
                 return error_at(peek(), "phys() expects an integer literal address");
             }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -153,6 +153,15 @@ void assign_expr_ids(curlee::parser::Expr& expr, std::size_t& next_id)
             {
                 assign_expr_ids(*node.base, next_id);
             }
+            else if constexpr (std::is_same_v<Node, curlee::parser::PhysReadExpr>)
+            {
+                assign_expr_ids(*node.base, next_id);
+            }
+            else if constexpr (std::is_same_v<Node, curlee::parser::PhysWriteExpr>)
+            {
+                assign_expr_ids(*node.base, next_id);
+                assign_expr_ids(*node.value, next_id);
+            }
             else if constexpr (std::is_same_v<Node, curlee::parser::GroupExpr>)
             {
                 assign_expr_ids(*node.inner, next_id);
@@ -384,7 +393,9 @@ class Parser
         if (match(TokenKind::KwCap))
         {
             const Token kw = previous();
-            if (!check(TokenKind::Identifier))
+            // Capability names may include the `phys` keyword segment (e.g. `cap phys.mem`).
+            const bool is_ident = check(TokenKind::Identifier) || check(TokenKind::KwPhys);
+            if (!is_ident)
             {
                 return error_at(peek(), "expected capability name after 'cap'");
             }
@@ -396,7 +407,9 @@ class Parser
             while (match(TokenKind::Dot))
             {
                 const Token dot = previous();
-                if (!check(TokenKind::Identifier))
+                const bool seg_is_ident =
+                    check(TokenKind::Identifier) || check(TokenKind::KwPhys);
+                if (!seg_is_ident)
                 {
                     return error_at(peek(), "expected identifier after '.' in capability name");
                 }
@@ -416,7 +429,8 @@ class Parser
             return TypeName{.span =
                                 curlee::source::Span{.start = kw.span.start, .end = last.span.end},
                             .is_capability = true,
-                            .name = name};
+                            .name = name,
+                            .type_arg = std::nullopt};
         }
 
         if (!check(TokenKind::Identifier))
@@ -424,7 +438,28 @@ class Parser
             return error_at(peek(), "expected type name");
         }
         const Token t = advance();
-        return TypeName{.span = t.span, .is_capability = false, .name = t.lexeme};
+        if (match(TokenKind::Less))
+        {
+            if (!check(TokenKind::Identifier))
+            {
+                return error_at(peek(), "expected type name after '<'");
+            }
+            const Token arg = advance();
+            if (auto err = consume(TokenKind::Greater, "expected '>' after type argument");
+                err.has_value())
+            {
+                return *err;
+            }
+            const Token gt = previous();
+            return TypeName{.span = curlee::source::Span{.start = t.span.start, .end = gt.span.end},
+                            .is_capability = false,
+                            .name = t.lexeme,
+                            .type_arg = arg.lexeme};
+        }
+        return TypeName{.span = t.span,
+                        .is_capability = false,
+                        .name = t.lexeme,
+                        .type_arg = std::nullopt};
     }
 
     [[nodiscard]] std::variant<ImportDecl, curlee::diag::Diagnostic> parse_import()
@@ -1685,6 +1720,50 @@ class Parser
                 }
                 const Token member = advance();
 
+                // Physical memory read: `base.read()`.
+                if (member.lexeme == "read" && check(TokenKind::LParen))
+                {
+                    advance(); // consume '('
+                    if (!check(TokenKind::RParen))
+                    {
+                        return error_at(peek(), "read() expects no arguments");
+                    }
+                    const Token rparen = advance();
+                    Expr access;
+                    access.span = span_cover(expr.span, rparen.span);
+                    access.node = curlee::parser::PhysReadExpr{
+                        .base = std::make_unique<Expr>(std::move(expr))};
+                    (void)dot;
+                    expr = std::move(access);
+                    continue;
+                }
+
+                // Physical memory write: `base.write(v)`.
+                if (member.lexeme == "write" && check(TokenKind::LParen))
+                {
+                    advance(); // consume '('
+                    auto value_res = parse_expr();
+                    if (std::holds_alternative<curlee::diag::Diagnostic>(value_res))
+                    {
+                        return std::get<curlee::diag::Diagnostic>(std::move(value_res));
+                    }
+                    Expr value = std::get<Expr>(std::move(value_res));
+                    if (auto err = consume(TokenKind::RParen, "expected ')' after write(...)");
+                        err.has_value())
+                    {
+                        return *err;
+                    }
+                    const Token rparen = previous();
+                    Expr access;
+                    access.span = span_cover(expr.span, rparen.span);
+                    access.node = curlee::parser::PhysWriteExpr{
+                        .base = std::make_unique<Expr>(std::move(expr)),
+                        .value = std::make_unique<Expr>(std::move(value))};
+                    (void)dot;
+                    expr = std::move(access);
+                    continue;
+                }
+
                 Expr access;
                 access.span = span_cover(expr.span, member.span);
                 access.node = MemberExpr{.base = std::make_unique<Expr>(std::move(expr)),
@@ -1877,6 +1956,49 @@ class Parser
             return expr;
         }
 
+        // Physical memory literal: `phys<U>(literal)`.
+        if (match(TokenKind::KwPhys))
+        {
+            const Token kw = previous();
+            if (auto err = consume(TokenKind::Less, "expected '<' after 'phys'");
+                err.has_value())
+            {
+                return *err;
+            }
+            if (!check(TokenKind::Identifier))
+            {
+                return error_at(peek(), "expected element type after 'phys<'");
+            }
+            const Token elem = advance();
+            if (auto err = consume(TokenKind::Greater, "expected '>' after element type");
+                err.has_value())
+            {
+                return *err;
+            }
+            if (auto err = consume(TokenKind::LParen, "expected '(' after 'phys<U>'");
+                err.has_value())
+            {
+                return *err;
+            }
+            if (!check(TokenKind::IntLiteral))
+            {
+                return error_at(peek(), "phys() expects an integer literal address");
+            }
+            const Token addr = advance();
+            if (auto err = consume(TokenKind::RParen, "expected ')' after phys address");
+                err.has_value())
+            {
+                return *err;
+            }
+            const Token rparen = previous();
+
+            Expr expr;
+            expr.span = span_cover(kw.span, rparen.span);
+            expr.node = curlee::parser::PhysExpr{.element_kind = elem.lexeme,
+                                                 .lexeme = addr.lexeme};
+            return expr;
+        }
+
         if (match(TokenKind::LParen))
         {
             const Token l = previous();
@@ -1984,6 +2106,10 @@ class Dumper
             return;
         }
         out_ << t.name;
+        if (t.type_arg.has_value())
+        {
+            out_ << "<" << *t.type_arg << ">";
+        }
     }
 
     void dump_struct_decl(const StructDecl& s)
@@ -2230,6 +2356,25 @@ class Dumper
             out_ << " ";
         }
         out_ << "}";
+    }
+
+    void dump_expr_node(const PhysExpr& e)
+    {
+        out_ << "phys<" << e.element_kind << ">(" << e.lexeme << ")";
+    }
+
+    void dump_expr_node(const PhysReadExpr& e)
+    {
+        dump_expr(*e.base);
+        out_ << ".read()";
+    }
+
+    void dump_expr_node(const PhysWriteExpr& e)
+    {
+        dump_expr(*e.base);
+        out_ << ".write(";
+        dump_expr(*e.value);
+        out_ << ")";
     }
 
     void dump_pred(const Pred& p)

--- a/src/resolver/resolver.cpp
+++ b/src/resolver/resolver.cpp
@@ -582,6 +582,31 @@ class Resolver
 
     void resolve_expr_node(const GroupExpr& e, Span) { resolve_expr(*e.inner); }
 
+    void resolve_expr_node(const curlee::parser::PhysExpr&, Span)
+    {
+        // `phys<U>(literal)` contains no variable references.
+    }
+
+    void resolve_expr_node(const curlee::parser::PhysReadExpr& e, Span)
+    {
+        if (e.base != nullptr)
+        {
+            resolve_expr(*e.base);
+        }
+    }
+
+    void resolve_expr_node(const curlee::parser::PhysWriteExpr& e, Span)
+    {
+        if (e.base != nullptr)
+        {
+            resolve_expr(*e.base);
+        }
+        if (e.value != nullptr)
+        {
+            resolve_expr(*e.value);
+        }
+    }
+
     void resolve_expr_node(const ScopedNameExpr&, Span)
     {
         // `Enum::Variant` is not a variable reference; do not call use_name().

--- a/src/types/type_check.cpp
+++ b/src/types/type_check.cpp
@@ -336,6 +336,42 @@ class Checker
             return Type{.kind = TypeKind::Capability, .name = name.name};
         }
 
+        // Physical memory pointer type: `Phys<U8|U16|U32|U64>`.
+        if (name.name == "Phys")
+        {
+            if (!name.type_arg.has_value())
+            {
+                error_at(name.span, "Phys requires an element type argument (Phys<U8|U16|U32|U64>)");
+                return std::nullopt;
+            }
+            const std::string_view elem = *name.type_arg;
+            TypeKind elem_kind;
+            if (elem == "U8")
+            {
+                elem_kind = TypeKind::U8;
+            }
+            else if (elem == "U16")
+            {
+                elem_kind = TypeKind::U16;
+            }
+            else if (elem == "U32")
+            {
+                elem_kind = TypeKind::U32;
+            }
+            else if (elem == "U64")
+            {
+                elem_kind = TypeKind::U64;
+            }
+            else
+            {
+                error_at(name.span, "unsupported Phys element kind '" + std::string(elem) +
+                                        "' (expected U8, U16, U32 or U64)");
+                return std::nullopt;
+            }
+            return Type{.kind = TypeKind::Phys, .name = "Phys", .element_kind = elem_kind,
+                        .element_name = elem};
+        }
+
         const auto t = core_type_from_name(name.name);
         if (!t.has_value())
         {
@@ -1455,6 +1491,147 @@ class Checker
         }
 
         return sig.result;
+    }
+
+    [[nodiscard]] std::optional<Type> check_expr_node(const curlee::parser::PhysExpr& e, Span span)
+    {
+        // Rule (1): the address must be a compile-time integer literal (decimal or hex).
+        const std::string_view lexeme = e.lexeme;
+        bool is_literal = !lexeme.empty();
+        if (is_literal)
+        {
+            for (std::size_t i = 0; i < lexeme.size(); ++i)
+            {
+                const char c = lexeme[i];
+                const bool is_digit = (c >= '0' && c <= '9');
+                const bool is_hex_digit = (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+                const bool is_hex_marker =
+                    (c == 'x' || c == 'X') && i == 1 && lexeme[0] == '0';
+                if (!is_digit && c != '_' && !is_hex_digit && !is_hex_marker)
+                {
+                    is_literal = false;
+                    break;
+                }
+            }
+        }
+        if (!is_literal)
+        {
+            error_at(span, "physical address must be a constant literal");
+            return std::nullopt;
+        }
+
+        TypeKind elem_kind;
+        if (e.element_kind == "U8")
+        {
+            elem_kind = TypeKind::U8;
+        }
+        else if (e.element_kind == "U16")
+        {
+            elem_kind = TypeKind::U16;
+        }
+        else if (e.element_kind == "U32")
+        {
+            elem_kind = TypeKind::U32;
+        }
+        else if (e.element_kind == "U64")
+        {
+            elem_kind = TypeKind::U64;
+        }
+        else
+        {
+            error_at(span, "unsupported Phys element kind '" + std::string(e.element_kind) +
+                               "' (expected U8, U16, U32 or U64)");
+            return std::nullopt;
+        }
+
+        return Type{.kind = TypeKind::Phys,
+                    .name = "Phys",
+                    .element_kind = elem_kind,
+                    .element_name = e.element_kind};
+    }
+
+    [[nodiscard]] std::optional<Type> check_expr_node(const curlee::parser::PhysReadExpr& e,
+                                                      Span span)
+    {
+        // Rules (2)+(3): read() only inside `unsafe` and requires `cap phys.mem`.
+        if (unsafe_depth_ == 0)
+        {
+            error_at(span, "physical memory access requires an unsafe block");
+            return std::nullopt;
+        }
+        require_capability("phys.mem", span);
+
+        if (e.base == nullptr) // GCOVR_EXCL_LINE
+        {
+            return std::nullopt; // GCOVR_EXCL_LINE
+        }
+        const auto base_t = check_expr(*e.base);
+        if (!base_t.has_value())
+        {
+            return std::nullopt;
+        }
+        if (base_t->kind != TypeKind::Phys)
+        {
+            error_at(span, "read() can only be called on a Phys<T> value");
+            return std::nullopt;
+        }
+        if (!base_t->element_kind.has_value()) // GCOVR_EXCL_LINE
+        {
+            return std::nullopt; // GCOVR_EXCL_LINE
+        }
+        // read() returns the element kind T.
+        return Type{.kind = *base_t->element_kind, .name = base_t->element_name};
+    }
+
+    [[nodiscard]] std::optional<Type> check_expr_node(const curlee::parser::PhysWriteExpr& e,
+                                                      Span span)
+    {
+        // Rules (2)+(3): write(v) only inside `unsafe` and requires `cap phys.mem`.
+        if (unsafe_depth_ == 0)
+        {
+            error_at(span, "physical memory access requires an unsafe block");
+            return std::nullopt;
+        }
+        require_capability("phys.mem", span);
+
+        if (e.base == nullptr || e.value == nullptr) // GCOVR_EXCL_LINE
+        {
+            return std::nullopt; // GCOVR_EXCL_LINE
+        }
+        const auto base_t = check_expr(*e.base);
+        if (!base_t.has_value())
+        {
+            return std::nullopt;
+        }
+        if (base_t->kind != TypeKind::Phys)
+        {
+            error_at(span, "write() can only be called on a Phys<T> value");
+            return std::nullopt;
+        }
+        if (!base_t->element_kind.has_value()) // GCOVR_EXCL_LINE
+        {
+            return std::nullopt; // GCOVR_EXCL_LINE
+        }
+        const auto value_t = check_expr(*e.value);
+        if (!value_t.has_value())
+        {
+            return std::nullopt;
+        }
+        // Accept Int literals when writing to unsigned element kinds (e.g. `fb.write(0xFF8800)`
+        // on Phys<U32>): the physical address space is little-endian byte-oriented and the
+        // compiler range-checks at the freestanding target. Exact unsigned types must still match.
+        const Type elem_type{.kind = *base_t->element_kind, .name = base_t->element_name};
+        const bool int_literal_for_unsigned =
+            (*value_t).kind == TypeKind::Int &&
+            (*base_t->element_kind == TypeKind::U8 || *base_t->element_kind == TypeKind::U16 ||
+             *base_t->element_kind == TypeKind::U32 || *base_t->element_kind == TypeKind::U64);
+        if (*value_t != elem_type && !int_literal_for_unsigned)
+        {
+            error_at(span, "write() value type mismatch: expected " +
+                               std::string(base_t->element_name) + ", got " +
+                               std::string(to_string(*value_t)));
+        }
+        return Type{.kind = TypeKind::Unit};
     }
 
     [[nodiscard]] std::optional<Type> check_expr_node(const GroupExpr& e, Span)

--- a/src/types/type_check.cpp
+++ b/src/types/type_check.cpp
@@ -345,30 +345,14 @@ class Checker
                 return std::nullopt;
             }
             const std::string_view elem = *name.type_arg;
-            TypeKind elem_kind;
-            if (elem == "U8")
-            {
-                elem_kind = TypeKind::U8;
-            }
-            else if (elem == "U16")
-            {
-                elem_kind = TypeKind::U16;
-            }
-            else if (elem == "U32")
-            {
-                elem_kind = TypeKind::U32;
-            }
-            else if (elem == "U64")
-            {
-                elem_kind = TypeKind::U64;
-            }
-            else
+            const auto elem_kind = phys_element_kind_from_name(elem);
+            if (!elem_kind.has_value())
             {
                 error_at(name.span, "unsupported Phys element kind '" + std::string(elem) +
                                         "' (expected U8, U16, U32 or U64)");
                 return std::nullopt;
             }
-            return Type{.kind = TypeKind::Phys, .name = "Phys", .element_kind = elem_kind,
+            return Type{.kind = TypeKind::Phys, .name = "Phys", .element_kind = *elem_kind,
                         .element_name = elem};
         }
 
@@ -1520,24 +1504,8 @@ class Checker
             return std::nullopt;
         }
 
-        TypeKind elem_kind;
-        if (e.element_kind == "U8")
-        {
-            elem_kind = TypeKind::U8;
-        }
-        else if (e.element_kind == "U16")
-        {
-            elem_kind = TypeKind::U16;
-        }
-        else if (e.element_kind == "U32")
-        {
-            elem_kind = TypeKind::U32;
-        }
-        else if (e.element_kind == "U64")
-        {
-            elem_kind = TypeKind::U64;
-        }
-        else
+        const auto elem_kind = phys_element_kind_from_name(e.element_kind);
+        if (!elem_kind.has_value())
         {
             error_at(span, "unsupported Phys element kind '" + std::string(e.element_kind) +
                                "' (expected U8, U16, U32 or U64)");
@@ -1546,7 +1514,7 @@ class Checker
 
         return Type{.kind = TypeKind::Phys,
                     .name = "Phys",
-                    .element_kind = elem_kind,
+                    .element_kind = *elem_kind,
                     .element_name = e.element_kind};
     }
 
@@ -1622,9 +1590,7 @@ class Checker
         // compiler range-checks at the freestanding target. Exact unsigned types must still match.
         const Type elem_type{.kind = *base_t->element_kind, .name = base_t->element_name};
         const bool int_literal_for_unsigned =
-            (*value_t).kind == TypeKind::Int &&
-            (*base_t->element_kind == TypeKind::U8 || *base_t->element_kind == TypeKind::U16 ||
-             *base_t->element_kind == TypeKind::U32 || *base_t->element_kind == TypeKind::U64);
+            (*value_t).kind == TypeKind::Int && is_phys_element_kind(*base_t->element_kind);
         if (*value_t != elem_type && !int_literal_for_unsigned)
         {
             error_at(span, "write() value type mismatch: expected " +

--- a/src/verification/checker.cpp
+++ b/src/verification/checker.cpp
@@ -277,6 +277,13 @@ class Verifier
             return TypeKind::Unit;
         }
 
+        // Physical memory pointers are freestanding-only; verification treats them as
+        // uninterpreted (opaque) values, matching the trusted-deref follow-up issue.
+        if (name.name == "Phys")
+        {
+            return TypeKind::Unit;
+        }
+
         auto t = curlee::types::core_type_from_name(name.name);
         if (!t.has_value())
         {
@@ -742,6 +749,24 @@ class Verifier
                 else if constexpr (std::is_same_v<Node, curlee::parser::GroupExpr>)
                 {
                     check_expr_for_calls(*node.inner);
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PhysReadExpr>)
+                {
+                    if (node.base)
+                    {
+                        check_expr_for_calls(*node.base);
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PhysWriteExpr>)
+                {
+                    if (node.base)
+                    {
+                        check_expr_for_calls(*node.base);
+                    }
+                    if (node.value)
+                    {
+                        check_expr_for_calls(*node.value);
+                    }
                 }
                 else
                 {

--- a/src/verification/checker.cpp
+++ b/src/verification/checker.cpp
@@ -863,11 +863,21 @@ class Verifier
             return;
         }
 
-        if (core_t->kind != TypeKind::Int && core_t->kind != TypeKind::Bool)
+        // Unsigned element kinds (U8/U16/U32/U64) are freestanding-only and treated as
+        // uninterpreted by verification, mirroring Phys<T> itself.
+        if (core_t->kind != TypeKind::Int && core_t->kind != TypeKind::Bool &&
+            !is_phys_element_kind(core_t->kind))
         {
             diags_.push_back(
                 error_at(s.type.span, "verification does not support type '" +
                                           std::string(curlee::types::to_string(*core_t)) + "'"));
+            check_expr_for_calls(s.value);
+            return;
+        }
+
+        if (is_phys_element_kind(core_t->kind))
+        {
+            // Uninterpreted: do not declare a solver variable, but still scan for calls.
             check_expr_for_calls(s.value);
             return;
         }

--- a/tests/cli_diagnostics/check_phys_arithmetic.golden
+++ b/tests/cli_diagnostics/check_phys_arithmetic.golden
@@ -1,0 +1,4 @@
+tests/fixtures/check_phys_arithmetic.curlee:4:18: error: '+' expects Int+Int or String+String
+  |
+  |     let x: Int = fb + 1;
+  |                  ^^^^^^

--- a/tests/cli_diagnostics/check_phys_missing_cap.golden
+++ b/tests/cli_diagnostics/check_phys_missing_cap.golden
@@ -1,0 +1,4 @@
+tests/fixtures/check_phys_missing_cap.curlee:4:18: error: missing capability value 'phys.mem' (add a parameter of type cap phys.mem)
+  |
+  |     let v: U32 = fb.read();
+  |                  ^^^^^^^^^

--- a/tests/cli_diagnostics/check_phys_non_literal_addr.golden
+++ b/tests/cli_diagnostics/check_phys_non_literal_addr.golden
@@ -1,0 +1,4 @@
+tests/fixtures/check_phys_non_literal_addr.curlee:4:35: error: phys() expects an integer literal address
+  |
+  |     let fb: Phys<U32> = phys<U32>(base + 4);
+  |                                   ^^^^

--- a/tests/cli_diagnostics/check_phys_outside_unsafe.golden
+++ b/tests/cli_diagnostics/check_phys_outside_unsafe.golden
@@ -1,0 +1,4 @@
+tests/fixtures/check_phys_outside_unsafe.curlee:3:16: error: physical memory access requires an unsafe block
+  |
+  |   let v: U32 = fb.read();
+  |                ^^^^^^^^^

--- a/tests/cli_diagnostics/check_phys_read_non_phys.golden
+++ b/tests/cli_diagnostics/check_phys_read_non_phys.golden
@@ -1,0 +1,4 @@
+tests/fixtures/check_phys_read_non_phys.curlee:4:18: error: read() can only be called on a Phys<T> value
+  |
+  |     let y: Int = x.read();
+  |                  ^^^^^^^^

--- a/tests/cli_diagnostics/check_phys_string_element.golden
+++ b/tests/cli_diagnostics/check_phys_string_element.golden
@@ -1,0 +1,4 @@
+tests/fixtures/check_phys_string_element.curlee:3:13: error: unsupported Phys element kind 'String' (expected U8, U16, U32 or U64)
+  |
+  |     let fb: Phys<String> = phys<String>(0xFD00_0000);
+  |             ^^^^^^^^^^^^

--- a/tests/cli_diagnostics_golden_tests.cpp
+++ b/tests/cli_diagnostics_golden_tests.cpp
@@ -898,6 +898,17 @@ int main(int argc, char** argv)
     const fs::path rel_type_error = fs::path("tests/fixtures/check_type_error.curlee");
     const fs::path rel_struct_ok = fs::path("tests/fixtures/check_struct_ok.curlee");
     const fs::path rel_ensures_fail = fs::path("tests/fixtures/check_ensures_fail.curlee");
+    const fs::path rel_phys_mem_ok = fs::path("tests/fixtures/check_phys_mem_ok.curlee");
+    const fs::path rel_phys_non_literal_addr =
+        fs::path("tests/fixtures/check_phys_non_literal_addr.curlee");
+    const fs::path rel_phys_outside_unsafe =
+        fs::path("tests/fixtures/check_phys_outside_unsafe.curlee");
+    const fs::path rel_phys_missing_cap = fs::path("tests/fixtures/check_phys_missing_cap.curlee");
+    const fs::path rel_phys_arithmetic = fs::path("tests/fixtures/check_phys_arithmetic.curlee");
+    const fs::path rel_phys_string_element =
+        fs::path("tests/fixtures/check_phys_string_element.curlee");
+    const fs::path rel_phys_read_non_phys =
+        fs::path("tests/fixtures/check_phys_read_non_phys.curlee");
     const fs::path rel_run_missing_stdout_cap = fs::path("tests/fixtures/r.curlee");
     const fs::path rel_run_missing_tty_cap = fs::path("tests/fixtures/run_missing_tty_cap.curlee");
     const fs::path rel_run_read_line = fs::path("tests/fixtures/run_read_line.curlee");
@@ -1019,6 +1030,63 @@ int main(int argc, char** argv)
                              {"curlee", "check", rel_struct_ok.string()},
                              dir / "check_struct_ok.golden",
                              true))
+        {
+            return 1;
+        }
+
+        // Front-end Phys<T> support (issue #252): positive fixture passes type checking.
+        if (!run_stderr_case("check-phys-mem-ok",
+                             {"curlee", "check", rel_phys_mem_ok.string()},
+                             dir / "check_phys_mem_ok.golden",
+                             true))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-non-literal-addr",
+                             {"curlee", "check", rel_phys_non_literal_addr.string()},
+                             dir / "check_phys_non_literal_addr.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-outside-unsafe",
+                             {"curlee", "check", rel_phys_outside_unsafe.string()},
+                             dir / "check_phys_outside_unsafe.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-missing-cap",
+                             {"curlee", "check", rel_phys_missing_cap.string()},
+                             dir / "check_phys_missing_cap.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-arithmetic",
+                             {"curlee", "check", rel_phys_arithmetic.string()},
+                             dir / "check_phys_arithmetic.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-string-element",
+                             {"curlee", "check", rel_phys_string_element.string()},
+                             dir / "check_phys_string_element.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-read-non-phys",
+                             {"curlee", "check", rel_phys_read_non_phys.string()},
+                             dir / "check_phys_read_non_phys.golden",
+                             false))
         {
             return 1;
         }

--- a/tests/compiler_tests.cpp
+++ b/tests/compiler_tests.cpp
@@ -1809,6 +1809,54 @@ fn main() -> Int {
                 }
             }
         }
+
+        // Phys<T> is freestanding-only: the VM emitter must reject all three Phys nodes.
+        using curlee::parser::PhysExpr;
+        using curlee::parser::PhysReadExpr;
+        using curlee::parser::PhysWriteExpr;
+
+        auto expect_phys_reject = [&](Expr root)
+        {
+            const auto emitted = run_with_expr(std::move(root));
+            if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(emitted))
+            {
+                fail("expected emission to fail for Phys node");
+            }
+            const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(emitted);
+            if (diags.empty() ||
+                diags[0].message.find("Phys is freestanding-only") == std::string::npos)
+            {
+                fail("expected freestanding-only diagnostic for Phys node");
+            }
+        };
+
+        {
+            // phys<U32>(0xFD00_0000) literal.
+            Expr root;
+            root.node = PhysExpr{.element_kind = "U32", .lexeme = "0xFD00_0000"};
+            expect_phys_reject(std::move(root));
+        }
+
+        {
+            // phys_value.read().
+            Expr base;
+            base.node = PhysExpr{.element_kind = "U32", .lexeme = "0xFD00_0000"};
+            Expr root;
+            root.node = PhysReadExpr{.base = std::make_unique<Expr>(std::move(base))};
+            expect_phys_reject(std::move(root));
+        }
+
+        {
+            // phys_value.write(v).
+            Expr base;
+            base.node = PhysExpr{.element_kind = "U32", .lexeme = "0xFD00_0000"};
+            Expr value;
+            value.node = curlee::parser::IntExpr{.lexeme = "1"};
+            Expr root;
+            root.node = PhysWriteExpr{.base = std::make_unique<Expr>(std::move(base)),
+                                      .value = std::make_unique<Expr>(std::move(value))};
+            expect_phys_reject(std::move(root));
+        }
     }
 
     {

--- a/tests/fixtures/check_phys_arithmetic.curlee
+++ b/tests/fixtures/check_phys_arithmetic.curlee
@@ -1,0 +1,7 @@
+fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    let x: Int = fb + 1;
+  }
+  return;
+}

--- a/tests/fixtures/check_phys_mem_ok.curlee
+++ b/tests/fixtures/check_phys_mem_ok.curlee
@@ -1,0 +1,8 @@
+fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000); // framebuffer base
+    fb.write(0xFF8800);                          // pixel write
+    let v: U32 = fb.read();                      // register/framebuffer read
+  }
+  return;
+}

--- a/tests/fixtures/check_phys_missing_cap.curlee
+++ b/tests/fixtures/check_phys_missing_cap.curlee
@@ -1,0 +1,7 @@
+fn main() -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    let v: U32 = fb.read();
+  }
+  return;
+}

--- a/tests/fixtures/check_phys_non_literal_addr.curlee
+++ b/tests/fixtures/check_phys_non_literal_addr.curlee
@@ -1,0 +1,7 @@
+fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let base: Int = 0xFD00_0000;
+    let fb: Phys<U32> = phys<U32>(base + 4);
+  }
+  return;
+}

--- a/tests/fixtures/check_phys_non_literal_addr.curlee
+++ b/tests/fixtures/check_phys_non_literal_addr.curlee
@@ -1,6 +1,6 @@
 fn main(pm: cap phys.mem) -> Unit {
   unsafe {
-    let base: Int = 0xFD00_0000;
+    let base: Int = 100;
     let fb: Phys<U32> = phys<U32>(base + 4);
   }
   return;

--- a/tests/fixtures/check_phys_outside_unsafe.curlee
+++ b/tests/fixtures/check_phys_outside_unsafe.curlee
@@ -1,0 +1,5 @@
+fn main(pm: cap phys.mem) -> Unit {
+  let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+  let v: U32 = fb.read();
+  return;
+}

--- a/tests/fixtures/check_phys_read_non_phys.curlee
+++ b/tests/fixtures/check_phys_read_non_phys.curlee
@@ -1,0 +1,7 @@
+fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let x: Int = 5;
+    let y: Int = x.read();
+  }
+  return;
+}

--- a/tests/fixtures/check_phys_string_element.curlee
+++ b/tests/fixtures/check_phys_string_element.curlee
@@ -1,0 +1,6 @@
+fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<String> = phys<String>(0xFD00_0000);
+  }
+  return;
+}

--- a/tests/lexer_tests.cpp
+++ b/tests/lexer_tests.cpp
@@ -39,7 +39,8 @@ int main()
     {
         constexpr TokenKind all_kinds[] = {
             TokenKind::Eof,           TokenKind::Identifier, TokenKind::IntLiteral,
-            TokenKind::StringLiteral, TokenKind::KwFn,       TokenKind::KwLet,
+            TokenKind::PhysAddrLiteral, TokenKind::StringLiteral, TokenKind::KwFn,
+            TokenKind::KwLet,
             TokenKind::KwIf,          TokenKind::KwElse,     TokenKind::KwWhile,
             TokenKind::KwReturn,      TokenKind::KwTrue,     TokenKind::KwFalse,
             TokenKind::KwRequires,    TokenKind::KwEnsures,  TokenKind::KwWhere,
@@ -98,9 +99,24 @@ int main()
         expect_token(toks, 2, TokenKind::Identifier, "U32");
         expect_token(toks, 3, TokenKind::Greater, ">");
         expect_token(toks, 4, TokenKind::LParen, "(");
-        expect_token(toks, 5, TokenKind::IntLiteral, "0xFD00_0000");
+        expect_token(toks, 5, TokenKind::PhysAddrLiteral, "0xFD00_0000");
         expect_token(toks, 6, TokenKind::RParen, ")");
         expect_token(toks, 7, TokenKind::Eof, "");
+    }
+
+    {
+        // Hex/underscore forms lex as a distinct token kind; a plain decimal stays IntLiteral.
+        const std::string src = "0xFF 1_000 42";
+        const auto res = lex(src);
+        if (!std::holds_alternative<std::vector<Token>>(res))
+        {
+            fail("expected success for mixed literal forms");
+        }
+        const auto& toks = std::get<std::vector<Token>>(res);
+        expect_token(toks, 0, TokenKind::PhysAddrLiteral, "0xFF");
+        expect_token(toks, 1, TokenKind::PhysAddrLiteral, "1_000");
+        expect_token(toks, 2, TokenKind::IntLiteral, "42");
+        expect_token(toks, 3, TokenKind::Eof, "");
     }
 
     {

--- a/tests/lexer_tests.cpp
+++ b/tests/lexer_tests.cpp
@@ -44,16 +44,17 @@ int main()
             TokenKind::KwReturn,      TokenKind::KwTrue,     TokenKind::KwFalse,
             TokenKind::KwRequires,    TokenKind::KwEnsures,  TokenKind::KwWhere,
             TokenKind::KwUnsafe,      TokenKind::KwCap,      TokenKind::KwImport,
-            TokenKind::KwAs,          TokenKind::KwStruct,   TokenKind::KwEnum,
-            TokenKind::KwMatch,       TokenKind::LParen,     TokenKind::RParen,
-            TokenKind::LBrace,        TokenKind::RBrace,     TokenKind::LBracket,
-            TokenKind::RBracket,      TokenKind::Semicolon,  TokenKind::Comma,
-            TokenKind::Colon,         TokenKind::ColonColon, TokenKind::Dot,
-            TokenKind::Arrow,         TokenKind::Equal,      TokenKind::EqualEqual,
-            TokenKind::Bang,          TokenKind::BangEqual,  TokenKind::Less,
-            TokenKind::LessEqual,     TokenKind::Greater,    TokenKind::GreaterEqual,
-            TokenKind::Plus,          TokenKind::Minus,      TokenKind::Star,
-            TokenKind::Slash,         TokenKind::AndAnd,     TokenKind::OrOr,
+            TokenKind::KwAs,          TokenKind::KwPhys,     TokenKind::KwStruct,
+            TokenKind::KwEnum,        TokenKind::KwMatch,    TokenKind::LParen,
+            TokenKind::RParen,        TokenKind::LBrace,     TokenKind::RBrace,
+            TokenKind::LBracket,      TokenKind::RBracket,   TokenKind::Semicolon,
+            TokenKind::Comma,         TokenKind::Colon,      TokenKind::ColonColon,
+            TokenKind::Dot,           TokenKind::Arrow,      TokenKind::Equal,
+            TokenKind::EqualEqual,    TokenKind::Bang,       TokenKind::BangEqual,
+            TokenKind::Less,          TokenKind::LessEqual,  TokenKind::Greater,
+            TokenKind::GreaterEqual,  TokenKind::Plus,       TokenKind::Minus,
+            TokenKind::Star,          TokenKind::Slash,      TokenKind::AndAnd,
+            TokenKind::OrOr,
         };
 
         for (const auto kind : all_kinds)
@@ -81,6 +82,34 @@ int main()
         const auto& toks = std::get<std::vector<Token>>(res);
         expect_token(toks, 0, TokenKind::KwMatch, "match");
         expect_token(toks, 1, TokenKind::Eof, "");
+    }
+
+    {
+        const std::string src = "phys<U32>(0xFD00_0000)";
+        const auto res = lex(src);
+        if (!std::holds_alternative<std::vector<Token>>(res))
+        {
+            fail("expected success for phys literal");
+        }
+
+        const auto& toks = std::get<std::vector<Token>>(res);
+        expect_token(toks, 0, TokenKind::KwPhys, "phys");
+        expect_token(toks, 1, TokenKind::Less, "<");
+        expect_token(toks, 2, TokenKind::Identifier, "U32");
+        expect_token(toks, 3, TokenKind::Greater, ">");
+        expect_token(toks, 4, TokenKind::LParen, "(");
+        expect_token(toks, 5, TokenKind::IntLiteral, "0xFD00_0000");
+        expect_token(toks, 6, TokenKind::RParen, ")");
+        expect_token(toks, 7, TokenKind::Eof, "");
+    }
+
+    {
+        const std::string src = "0x1F 0Xff 42 0x";
+        const auto res = lex(src);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(res))
+        {
+            fail("expected error for dangling '0x'");
+        }
     }
 
     {

--- a/tests/lsp_internal_tests.cpp
+++ b/tests/lsp_internal_tests.cpp
@@ -534,6 +534,20 @@ int main()
         {
             fail("expected analyze to succeed on valid program");
         }
+
+        // Phys<T> nodes must not crash LSP analysis or produce spurious diagnostics.
+        file.contents = "fn main(pm: cap phys.mem) -> Unit { unsafe { let fb: Phys<U32> = "
+                        "phys<U32>(0xFD00_0000); fb.write(0xFF8800); let v: U32 = fb.read(); } "
+                        "return; }";
+        const auto d_phys = collect_diagnostics(file);
+        if (!d_phys.empty())
+        {
+            fail("expected no diagnostics for valid Phys program");
+        }
+        if (!analyze(file).has_value())
+        {
+            fail("expected analyze to succeed on valid Phys program");
+        }
     }
 
     {

--- a/tests/lsp_internal_tests.ipp
+++ b/tests/lsp_internal_tests.ipp
@@ -534,6 +534,20 @@ int main()
         {
             fail("expected analyze to succeed on valid program");
         }
+
+        // Phys<T> nodes must not crash LSP analysis or produce spurious diagnostics.
+        file.contents = "fn main(pm: cap phys.mem) -> Unit { unsafe { let fb: Phys<U32> = "
+                        "phys<U32>(0xFD00_0000); fb.write(0xFF8800); let v: U32 = fb.read(); } "
+                        "return; }";
+        const auto d_phys = collect_diagnostics(file);
+        if (!d_phys.empty())
+        {
+            fail("expected no diagnostics for valid Phys program");
+        }
+        if (!analyze(file).has_value())
+        {
+            fail("expected analyze to succeed on valid Phys program");
+        }
     }
 
     {

--- a/tests/parser_tests.cpp
+++ b/tests/parser_tests.cpp
@@ -170,6 +170,61 @@ fn main(v: Option) -> Unit {
             "expected '}' after match arms");
     }
 
+    // Phys<T>: parse success + dump parity for phys literal, .read(), .write().
+    {
+        const std::string src = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    fb.write(0xFF8800);
+    let v: U32 = fb.read();
+  }
+  return;
+}
+)";
+        const auto lexed = lexer::lex(src);
+        if (!std::holds_alternative<std::vector<lexer::Token>>(lexed))
+        {
+            fail("lex failed on Phys program");
+        }
+        const auto& toks = std::get<std::vector<lexer::Token>>(lexed);
+        const auto parsed = parser::parse(toks);
+        if (!std::holds_alternative<parser::Program>(parsed))
+        {
+            fail("parse failed on Phys program");
+        }
+        const auto& prog = std::get<parser::Program>(parsed);
+        const std::string dumped = parser::dump(prog);
+        if (dumped.find("phys<U32>(0xFD00_0000)") == std::string::npos)
+        {
+            fail("dump missing phys literal rendering");
+        }
+        if (dumped.find(".write(0xFF8800)") == std::string::npos)
+        {
+            fail("dump missing phys write rendering");
+        }
+        if (dumped.find(".read()") == std::string::npos)
+        {
+            fail("dump missing phys read rendering");
+        }
+        if (dumped.find("Phys<U32>") == std::string::npos)
+        {
+            fail("dump missing Phys<U32> type rendering");
+        }
+    }
+
+    // Phys<T>: malformed forms produce deterministic diagnostics.
+    {
+        expect_parse_error_contains("fn main() -> Unit { let x: Phys<U32> = phys; return; }",
+                                    "expected '<' after 'phys'");
+        expect_parse_error_contains("fn main() -> Unit { let x: Phys<U32> = phys<; return; }",
+                                    "expected element type after 'phys<'");
+        expect_parse_error_contains("fn main() -> Unit { let x: Phys<U32> = phys<U32>; return; }",
+                                    "expected '(' after 'phys<U>'");
+        expect_parse_error_contains(
+            "fn main() -> Unit { let x: Phys<U32> = phys<U32>(base); return; }",
+            "phys() expects an integer literal address");
+    }
+
     // Struct literal: duplicate field initializer.
     {
         const std::string src = R"(struct Point { x: Int; }

--- a/tests/resolver_tests.cpp
+++ b/tests/resolver_tests.cpp
@@ -819,6 +819,25 @@ fn main(v: E) -> Unit {
         }
     }
 
+    {
+        // Phys<T> nodes must not crash the resolver: `phys<U32>(lit)`, `.read()`, `.write(v)`
+        // contain no unresolved variable references.
+        const std::string src = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    fb.write(0xFF8800);
+    let v: U32 = fb.read();
+  }
+  return;
+})";
+
+        const auto res = resolve_with_source(src, "tests/fixtures/resolve_phys_mem.curlee");
+        if (!std::holds_alternative<resolver::Resolution>(res))
+        {
+            fail("expected resolver success for Phys nodes");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/types_tests.cpp
+++ b/tests/types_tests.cpp
@@ -1442,6 +1442,544 @@ int main()
         }
     }
 
+    // Phys<T>: TypeKind stringification and equality for the new kinds.
+    {
+        if (to_string(TypeKind::U8) != "U8" || to_string(TypeKind::U16) != "U16" ||
+            to_string(TypeKind::U32) != "U32" || to_string(TypeKind::U64) != "U64" ||
+            to_string(TypeKind::Phys) != "Phys")
+        {
+            fail("expected unsigned and Phys TypeKind stringification to work");
+        }
+        if (to_string(Type{.kind = TypeKind::Phys,
+                          .name = "Phys",
+                          .element_kind = TypeKind::U32,
+                          .element_name = "U32"}) != "Phys")
+        {
+            fail("expected Phys Type stringification to return Phys");
+        }
+
+        const Type phys_u32{.kind = TypeKind::Phys,
+                            .name = "Phys",
+                            .element_kind = TypeKind::U32,
+                            .element_name = "U32"};
+        const Type phys_u32_same{.kind = TypeKind::Phys,
+                                 .name = "Phys",
+                                 .element_kind = TypeKind::U32,
+                                 .element_name = "U32"};
+        const Type phys_u8{.kind = TypeKind::Phys,
+                           .name = "Phys",
+                           .element_kind = TypeKind::U8,
+                           .element_name = "U8"};
+        if (!(phys_u32 == phys_u32_same) || (phys_u32 == phys_u8))
+        {
+            fail("expected Phys equality to respect element kind");
+        }
+    }
+
+    // Phys<T>: core_type_from_name and element-kind helpers.
+    {
+        if (core_type_from_name("U8") != Type{.kind = TypeKind::U8})
+        {
+            fail("expected U8 core type");
+        }
+        if (core_type_from_name("U16") != Type{.kind = TypeKind::U16})
+        {
+            fail("expected U16 core type");
+        }
+        if (core_type_from_name("U32") != Type{.kind = TypeKind::U32})
+        {
+            fail("expected U32 core type");
+        }
+        if (core_type_from_name("U64") != Type{.kind = TypeKind::U64})
+        {
+            fail("expected U64 core type");
+        }
+        if (phys_element_kind_from_name("U8") != TypeKind::U8 ||
+            phys_element_kind_from_name("U16") != TypeKind::U16 ||
+            phys_element_kind_from_name("U32") != TypeKind::U32 ||
+            phys_element_kind_from_name("U64") != TypeKind::U64 ||
+            phys_element_kind_from_name("String").has_value())
+        {
+            fail("expected phys element-kind resolution to work");
+        }
+        if (!is_phys_element_kind(TypeKind::U8) || !is_phys_element_kind(TypeKind::U64) ||
+            is_phys_element_kind(TypeKind::Int))
+        {
+            fail("expected is_phys_element_kind to be exact");
+        }
+    }
+
+    // Phys<T>: positive fixture passes type checking (unsafe + cap phys.mem).
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    fb.write(0xFF8800);
+    let v: U32 = fb.read();
+  }
+  return;
+}
+)";
+        (void)type_check_should_succeed(source, "phys positive fixture");
+    }
+
+    // Phys<T>: all four supported element kinds type-check.
+    {
+        for (const auto* kind : {"U8", "U16", "U32", "U64"})
+        {
+            const std::string source = std::string(R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<)") + kind + R"(> = phys<)" + kind + R"(>(0x1000);
+  }
+  return;
+}
+)";
+            (void)type_check_should_succeed(source, "phys element kind " + std::string(kind));
+        }
+    }
+
+    // Phys<T>: read/write outside `unsafe` fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+  let v: U32 = fb.read();
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys read outside unsafe");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("requires an unsafe block") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected unsafe-block diagnostic for phys read");
+        }
+    }
+
+    // Phys<T>: missing `cap phys.mem` parameter fails.
+    {
+        const std::string source = R"(fn main() -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    let v: U32 = fb.read();
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys missing cap");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("phys.mem") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected missing phys.mem capability diagnostic");
+        }
+    }
+
+    // Phys<T>: non-literal addresses are rejected at parse time (parser requires a literal),
+    // so the type-checker constant-literal rule is defense-in-depth only. Verify the parse
+    // rejection surfaces a stable diagnostic.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(100 + 4);
+  }
+  return;
+}
+)";
+        const auto lexed = curlee::lexer::lex(source);
+        const auto& toks = std::get<std::vector<curlee::lexer::Token>>(lexed);
+        const auto parsed = curlee::parser::parse(toks);
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(parsed))
+        {
+            fail("expected parse failure for phys non-literal address");
+        }
+        bool saw = false;
+        for (const auto& d : std::get<std::vector<curlee::diag::Diagnostic>>(parsed))
+        {
+            if (d.message.find("phys() expects an integer literal address") != std::string::npos ||
+                d.message.find("expected ')' after phys address") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected literal-address parse diagnostic for phys non-literal address");
+        }
+    }
+
+    // Phys<T>: arithmetic on Phys<T> fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    let x: Int = fb + 1;
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys arithmetic");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("'+' expects") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected arithmetic-on-Phys diagnostic");
+        }
+    }
+
+    // Phys<T>: unsupported element kind (Phys<String>) fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<String> = phys<String>(0xFD00_0000);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys string element");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("unsupported Phys element kind") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected unsupported Phys element kind diagnostic");
+        }
+    }
+
+    // Phys<T>: `Phys` without a type argument fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys = phys<U32>(0xFD00_0000);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys missing type arg");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("Phys requires an element type argument") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected missing type-argument diagnostic for Phys");
+        }
+    }
+
+    // Phys<T>: read() on a non-Phys value fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let x: Int = 5;
+    let y: Int = x.read();
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys read on non-phys");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("read() can only be called on a Phys<T> value") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected read-on-non-Phys diagnostic");
+        }
+    }
+
+    // Phys<T>: write() with a wrong (non-Int) value type fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    fb.write(true);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys write value type mismatch");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("write() value type mismatch") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected write value type mismatch diagnostic");
+        }
+    }
+
+    // Phys<T>: write() on a non-Phys value fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let x: Int = 5;
+    x.write(1);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys write on non-phys");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("write() can only be called on a Phys<T> value") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected write-on-non-Phys diagnostic");
+        }
+    }
+
+    // Phys<T>: write() outside `unsafe` fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+  fb.write(1);
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys write outside unsafe");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("requires an unsafe block") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected unsafe-block diagnostic for phys write");
+        }
+    }
+
+    // Phys<T>: read() on an unknown name fails type-check of the base expression
+    // (exercises the `!base_t.has_value()` guard in the read handler).
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let v: U32 = missing.read();
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys read on unknown base");
+        bool saw_unknown = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("unknown name") != std::string::npos)
+            {
+                saw_unknown = true;
+            }
+        }
+        if (!saw_unknown)
+        {
+            fail("expected unknown-name diagnostic for phys read base");
+        }
+    }
+
+    // Phys<T>: write() with an unknown value name fails type-check of the value
+    // (exercises the `!value_t.has_value()` guard in the write handler).
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    fb.write(missing);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys write unknown value");
+        bool saw_unknown = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("unknown name") != std::string::npos)
+            {
+                saw_unknown = true;
+            }
+        }
+        if (!saw_unknown)
+        {
+            fail("expected unknown-name diagnostic for phys write value");
+        }
+    }
+
+    // Phys<T>: write() on an unknown base name fails type-check of the base
+    // (exercises the `!base_t.has_value()` guard in the write handler).
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    missing.write(1);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys write unknown base");
+        bool saw_unknown = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("unknown name") != std::string::npos)
+            {
+                saw_unknown = true;
+            }
+        }
+        if (!saw_unknown)
+        {
+            fail("expected unknown-name diagnostic for phys write base");
+        }
+    }
+
+    // Phys<T>: directly-constructed AST reaches the defensive literal-validation and
+    // element-kind branches that the parser otherwise prevents (defense in depth).
+    {
+        // Bad element kind on the PhysExpr (parser accepts any identifier, so the
+        // type checker is the final gate).
+        curlee::parser::Program prog_bad_elem;
+        {
+            curlee::parser::Function f;
+            f.name = "main";
+            f.span = {};
+            f.return_type = curlee::parser::TypeName{.span = {}, .name = "Unit"};
+
+            // let fb: Phys<U32> = phys<Bad>(0x1000);
+            curlee::parser::Expr phys_expr;
+            phys_expr.span = {};
+            phys_expr.node = curlee::parser::PhysExpr{.element_kind = "Bad",
+                                                      .lexeme = "0x1000"};
+
+            curlee::parser::TypeName fb_type;
+            fb_type.span = {};
+            fb_type.name = "Phys";
+            fb_type.type_arg = "U32";
+
+            curlee::parser::LetStmt let_stmt;
+            let_stmt.name = "fb";
+            let_stmt.type = fb_type;
+            let_stmt.value = std::move(phys_expr);
+
+            curlee::parser::Stmt s;
+            s.span = {};
+            s.node = std::move(let_stmt);
+            f.body.stmts.push_back(std::move(s));
+
+            curlee::parser::Stmt ret;
+            ret.span = {};
+            ret.node = curlee::parser::ReturnStmt{.value = std::nullopt};
+            f.body.stmts.push_back(std::move(ret));
+
+            prog_bad_elem.functions.push_back(std::move(f));
+        }
+
+        const auto typed_bad = curlee::types::type_check(prog_bad_elem);
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(typed_bad))
+        {
+            fail("expected type check failure for bad Phys element kind");
+        }
+        bool saw_bad_kind = false;
+        for (const auto& d : std::get<std::vector<curlee::diag::Diagnostic>>(typed_bad))
+        {
+            if (d.message.find("unsupported Phys element kind") != std::string::npos)
+            {
+                saw_bad_kind = true;
+            }
+        }
+        if (!saw_bad_kind)
+        {
+            fail("expected unsupported Phys element kind diagnostic from direct AST");
+        }
+
+        // Bad (non-literal) address lexeme reaches the constant-literal guard.
+        curlee::parser::Program prog_bad_addr;
+        {
+            curlee::parser::Function f;
+            f.name = "main";
+            f.span = {};
+            f.return_type = curlee::parser::TypeName{.span = {}, .name = "Unit"};
+
+            curlee::parser::Expr phys_expr;
+            phys_expr.span = {};
+            phys_expr.node = curlee::parser::PhysExpr{.element_kind = "U32",
+                                                      .lexeme = "base + 4"};
+
+            curlee::parser::TypeName fb_type;
+            fb_type.span = {};
+            fb_type.name = "Phys";
+            fb_type.type_arg = "U32";
+
+            curlee::parser::LetStmt let_stmt;
+            let_stmt.name = "fb";
+            let_stmt.type = fb_type;
+            let_stmt.value = std::move(phys_expr);
+
+            curlee::parser::Stmt s;
+            s.span = {};
+            s.node = std::move(let_stmt);
+            f.body.stmts.push_back(std::move(s));
+
+            curlee::parser::Stmt ret;
+            ret.span = {};
+            ret.node = curlee::parser::ReturnStmt{.value = std::nullopt};
+            f.body.stmts.push_back(std::move(ret));
+
+            prog_bad_addr.functions.push_back(std::move(f));
+        }
+
+        const auto typed_addr = curlee::types::type_check(prog_bad_addr);
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(typed_addr))
+        {
+            fail("expected type check failure for non-literal phys address");
+        }
+        bool saw_addr = false;
+        for (const auto& d : std::get<std::vector<curlee::diag::Diagnostic>>(typed_addr))
+        {
+            if (d.message.find("physical address must be a constant literal") != std::string::npos)
+            {
+                saw_addr = true;
+            }
+        }
+        if (!saw_addr)
+        {
+            fail("expected constant-literal diagnostic from direct AST");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/types_tests.ipp
+++ b/tests/types_tests.ipp
@@ -2836,6 +2836,214 @@ int main()
         }
     }
 
+    // Phys<T>: TypeKind stringification and equality for the new kinds.
+    {
+        if (to_string(TypeKind::U8) != "U8" || to_string(TypeKind::U16) != "U16" ||
+            to_string(TypeKind::U32) != "U32" || to_string(TypeKind::U64) != "U64" ||
+            to_string(TypeKind::Phys) != "Phys")
+        {
+            fail("expected unsigned and Phys TypeKind stringification to work");
+        }
+
+        const Type phys_u32{.kind = TypeKind::Phys,
+                            .name = "Phys",
+                            .element_kind = TypeKind::U32,
+                            .element_name = "U32"};
+        const Type phys_u32_same{.kind = TypeKind::Phys,
+                                 .name = "Phys",
+                                 .element_kind = TypeKind::U32,
+                                 .element_name = "U32"};
+        const Type phys_u8{.kind = TypeKind::Phys,
+                           .name = "Phys",
+                           .element_kind = TypeKind::U8,
+                           .element_name = "U8"};
+        if (!(phys_u32 == phys_u32_same) || (phys_u32 == phys_u8))
+        {
+            fail("expected Phys equality to respect element kind");
+        }
+    }
+
+    // Phys<T>: core_type_from_name recognizes the unsigned types.
+    {
+        if (core_type_from_name("U8") != Type{.kind = TypeKind::U8})
+        {
+            fail("expected U8 core type");
+        }
+        if (core_type_from_name("U16") != Type{.kind = TypeKind::U16})
+        {
+            fail("expected U16 core type");
+        }
+        if (core_type_from_name("U32") != Type{.kind = TypeKind::U32})
+        {
+            fail("expected U32 core type");
+        }
+        if (core_type_from_name("U64") != Type{.kind = TypeKind::U64})
+        {
+            fail("expected U64 core type");
+        }
+    }
+
+    // Phys<T>: positive fixture passes type checking (unsafe + cap phys.mem).
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    fb.write(0xFF8800);
+    let v: U32 = fb.read();
+  }
+  return;
+}
+)";
+        (void)type_check_should_succeed(source, "phys positive fixture");
+    }
+
+    // Phys<T>: read/write outside `unsafe` fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+  let v: U32 = fb.read();
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys read outside unsafe");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("requires an unsafe block") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected unsafe-block diagnostic for phys read");
+        }
+    }
+
+    // Phys<T>: missing `cap phys.mem` parameter fails.
+    {
+        const std::string source = R"(fn main() -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    let v: U32 = fb.read();
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys missing cap");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("phys.mem") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected missing phys.mem capability diagnostic");
+        }
+    }
+
+    // Phys<T>: non-literal address fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000 + 4);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys non-literal address");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("physical address must be a constant literal") != std::string::npos ||
+                d.message.find("phys() expects an integer literal address") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected constant-literal diagnostic for phys address");
+        }
+    }
+
+    // Phys<T>: arithmetic on Phys<T> fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000);
+    let x: Int = fb + 1;
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys arithmetic");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("'+' expects") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected arithmetic-on-Phys diagnostic");
+        }
+    }
+
+    // Phys<T>: unsupported element kind (Phys<String>) fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<String> = phys<String>(0xFD00_0000);
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys string element");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("unsupported Phys element kind") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected unsupported Phys element kind diagnostic");
+        }
+    }
+
+    // Phys<T>: read() on a non-Phys value fails.
+    {
+        const std::string source = R"(fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let x: Int = 5;
+    let y: Int = x.read();
+  }
+  return;
+}
+)";
+        const auto diags = type_check_should_fail(source, "phys read on non-phys");
+        bool saw = false;
+        for (const auto& d : diags)
+        {
+            if (d.message.find("read() can only be called on a Phys<T> value") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected read-on-non-Phys diagnostic");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/verification_checker_internal_tests.ipp
+++ b/tests/verification_checker_internal_tests.ipp
@@ -24,13 +24,8 @@ static void fail(const std::string& msg)
 #include "../src/verification/checker.cpp"
 #undef private
 
-static curlee::parser::Expr make_expr(
-    curlee::source::Span span,
-    std::variant<curlee::parser::IntExpr, curlee::parser::BoolExpr, curlee::parser::StringExpr,
-                 curlee::parser::NameExpr, curlee::parser::UnaryExpr, curlee::parser::BinaryExpr,
-                 curlee::parser::CallExpr, curlee::parser::MemberExpr, curlee::parser::GroupExpr,
-                 curlee::parser::ScopedNameExpr, curlee::parser::StructLiteralExpr>
-        node)
+static curlee::parser::Expr make_expr(curlee::source::Span span,
+                                      decltype(curlee::parser::Expr::node) node)
 {
     curlee::parser::Expr e;
     e.span = span;

--- a/tests/verification_checker_tests.cpp
+++ b/tests/verification_checker_tests.cpp
@@ -842,6 +842,30 @@ int main()
         }
     }
 
+    {
+        // Phys<T> is freestanding-only: the verifier treats it as uninterpreted (opaque)
+        // and must not error on the type or on phys/read/write expression nodes.
+        const std::string source = "fn main(pm: cap phys.mem) -> Unit [ ensures true; ] {\n"
+                                   "  unsafe {\n"
+                                   "    let fb: Phys<U32> = phys<U32>(0xFD00_0000);\n"
+                                   "    fb.write(0xFF8800);\n"
+                                   "    let v: U32 = fb.read();\n"
+                                   "  }\n"
+                                   "  return;\n"
+                                   "}\n";
+
+        const auto verified = verify_program(source, "Phys treated as uninterpreted in verifier");
+        if (!std::holds_alternative<curlee::verification::Verified>(verified))
+        {
+            const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(verified);
+            for (const auto& d : diags)
+            {
+                std::cerr << "DIAG: " << d.message << "\n";
+            }
+            fail("expected verification to succeed for Phys program (uninterpreted type)");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }


### PR DESCRIPTION
Closes #252

## Summary

Adds the **front-end surface** for raw physical memory pointer contracts, as specified in issue #252. This is the first of two pointer issues: syntax/type-checking only — no verifier semantics, no bytecode/VM support (freestanding-only by design).

### Language surface

```curlee
fn main(pm: cap phys.mem) -> Unit {
  unsafe {
    let fb: Phys<U32> = phys<U32>(0xFD00_0000); // framebuffer base (constant only)
    fb.write(0xFF8800);                          // pixel write
    let v: U32 = fb.read();                      // register/framebuffer read
  }
}
```

### Type-check rules enforced

1. `phys<U>(...)` address must be a compile-time integer literal (decimal or hex, `_` separators allowed).
2. `read()` / `write(v)` may appear only inside an `unsafe` block.
3. The enclosing function must have an in-scope `cap phys.mem` parameter.
4. `Phys<T>` is not arithmetic-able; `read` returns `T`, `write` takes `T` and returns `Unit`. Int literals are accepted when writing unsigned element kinds (`fb.write(0xFF8800)` on `Phys<U32>`).

## Changes

- **Lexer**: `KwPhys` keyword; hex integer literals (`0xFD00_0000`) with `_` separators.
- **Parser/AST**: `PhysExpr{element_kind, lexeme}`, `PhysReadExpr{base}`, `PhysWriteExpr{base, value}`; primary/postfix grammar for `phys<U>(literal)`, `.read()`, `.write(v)`; generic type arguments (`Phys<U32>` type names) with dump parity.
- **Types**: `TypeKind::U8/U16/U32/U64` and `TypeKind::Phys` (element-kind-aware equality/stringification, `core_type_from_name`).
- **Type checker**: rules (1)–(4) above with span-accurate diagnostics; `unsafe_depth_` gating reused.
- **Resolver/LSP**: no-crash traversal for the new nodes (dump/hover parity).
- **Emitter**: VM rejects Phys programs with `"Phys is freestanding-only and not supported in the VM"`.
- **Verifier**: `Phys` treated as uninterpreted (freestanding-only); the trusted-deref follow-up issue adds verifier semantics.

## Tests

- Unit tests: lexer (`KwPhys`, hex/underscore literals), parser (parse + dump parity + malformed forms), types (`TypeKind` equality/stringification + all four gating rules), resolver (no-crash), LSP internal (analyze/diagnostics on a Phys program).
- Fixtures + golden CLI diagnostics: 1 positive (`check_phys_mem_ok`) and 6 negative fixtures (`non_literal_addr`, `outside_unsafe`, `missing_cap`, `arithmetic`, `string_element`, `read_non_phys`) with stable, span-accurate golden output.

## Verification

- `ctest --preset linux-debug` (61/62 pass; the one failure is a pre-existing `clang-format`-not-installed environment issue in `curlee_cli_fmt_tests`, unrelated to this change).