### PR TITLE
Verifier: trusted/opaque Phys<T> deref semantics (issue #253)

### DIFF
--- a/src/verification/checker.cpp
+++ b/src/verification/checker.cpp
@@ -194,6 +194,33 @@ Diagnostic error_at(Span span, std::string message)
     return d;
 }
 
+/**
+ * @brief True if the phys address lexeme is a plain constant literal.
+ *
+ * Accepts decimal integers and hex literals (0x...) with underscore separators.
+ * This is the verifier's second-line enforcement: the front-end already rejects
+ * non-literals, but the verifier must not trust the AST (defense in depth).
+ */
+bool is_phys_address_literal(std::string_view lexeme)
+{
+    if (lexeme.empty())
+    {
+        return false;
+    }
+    for (std::size_t i = 0; i < lexeme.size(); ++i)
+    {
+        const char c = lexeme[i];
+        const bool is_digit = (c >= '0' && c <= '9');
+        const bool is_hex_digit = (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+        const bool is_hex_marker = (c == 'x' || c == 'X') && i == 1 && lexeme[0] == '0';
+        if (!is_digit && c != '_' && !is_hex_digit && !is_hex_marker)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 struct FunctionSig
 {
     const Function* decl = nullptr;
@@ -205,6 +232,10 @@ struct ScopeState
 {
     std::unordered_map<std::string_view, z3::expr> int_vars;
     std::unordered_map<std::string_view, z3::expr> bool_vars;
+    // Phys<T> pointer variables, mapped to their element kind name (e.g. "U32").
+    std::unordered_map<std::string_view, std::string_view> phys_vars;
+    // Names bound from a Phys read() result (opaque values that cannot be contracted).
+    std::unordered_set<std::string_view> opaque_read_vars;
     std::size_t facts_size = 0;
 };
 
@@ -241,12 +272,19 @@ class Verifier
     std::vector<ScopeState> scopes_;
     std::unordered_map<std::string_view, FunctionSig> functions_;
 
+    // Phys<T> pointer variables (name -> element kind name), scoped like int/bool vars.
+    std::unordered_map<std::string_view, std::string_view> phys_vars_;
+    // Names bound from a Phys read() result; contracts referencing these cannot be proven.
+    std::unordered_set<std::string_view> opaque_read_vars_;
+
     void push_scope()
     {
         scopes_.emplace_back();
         auto& state = scopes_.back();
         state.int_vars = lower_ctx_.int_vars;
         state.bool_vars = lower_ctx_.bool_vars;
+        state.phys_vars = phys_vars_;
+        state.opaque_read_vars = opaque_read_vars_;
         state.facts_size = facts_.size();
     }
 
@@ -260,6 +298,8 @@ class Verifier
         scopes_.pop_back();
         lower_ctx_.int_vars = state.int_vars;
         lower_ctx_.bool_vars = state.bool_vars;
+        phys_vars_ = state.phys_vars;
+        opaque_read_vars_ = state.opaque_read_vars;
         if (facts_.size() > state.facts_size)
         {
             facts_.erase(facts_.begin() + static_cast<std::ptrdiff_t>(state.facts_size),
@@ -277,11 +317,12 @@ class Verifier
             return TypeKind::Unit;
         }
 
-        // Physical memory pointers are freestanding-only; verification treats them as
-        // uninterpreted (opaque) values, matching the trusted-deref follow-up issue.
+        // Physical memory pointers are freestanding-only. Verification models them as opaque
+        // Z3 sorts (one per element kind) with uninterpreted read/write functions, so they
+        // are a distinct TypeKind here (not Unit like capabilities).
         if (name.name == "Phys")
         {
-            return TypeKind::Unit;
+            return TypeKind::Phys;
         }
 
         auto t = curlee::types::core_type_from_name(name.name);
@@ -349,6 +390,15 @@ class Verifier
         {
             return ExprValue{it->second, TypeKind::Bool, false};
         }
+        // Phys<T> pointers are opaque values; a bare name reference lowers to a constant of
+        // the opaque sort (used as the base of read()/write()).
+        if (auto it = phys_vars_.find(name); it != phys_vars_.end())
+        {
+            const std::string const_name = std::string("phys_var_") + std::string(name);
+            const z3::sort& sort = phys_sort(it->second);
+            return ExprValue{solver_.context().constant(const_name.c_str(), sort), TypeKind::Phys,
+                             false};
+        }
         return std::nullopt;
     }
 
@@ -369,12 +419,144 @@ class Verifier
         }
     }
 
+    // One fresh opaque Z3 sort per Phys element kind (e.g. "PhysU32").
+    std::unordered_map<std::string_view, z3::sort> phys_sorts_;
+    // Uninterpreted read function per element kind: phys_read : Phys<T> -> T.
+    std::unordered_map<std::string_view, z3::func_decl> phys_read_fns_;
+    // Uninterpreted write function per element kind: phys_write : Phys<T> x T -> Unit.
+    std::unordered_map<std::string_view, z3::func_decl> phys_write_fns_;
+
+    const z3::sort& phys_sort(std::string_view element_kind)
+    {
+        auto it = phys_sorts_.find(element_kind);
+        if (it != phys_sorts_.end())
+        {
+            return it->second;
+        }
+        const std::string name = "Phys" + std::string(element_kind);
+        auto [inserted_it, _] = phys_sorts_.emplace(
+            element_kind, solver_.context().uninterpreted_sort(name.c_str()));
+        return inserted_it->second;
+    }
+
+    const z3::func_decl& phys_read_fn(std::string_view element_kind)
+    {
+        auto it = phys_read_fns_.find(element_kind);
+        if (it != phys_read_fns_.end())
+        {
+            return it->second;
+        }
+        auto& ctx = solver_.context();
+        const std::string name = "phys_read_" + std::string(element_kind);
+        // phys_read : Phys<T> -> Int. Values are opaque; no axioms constrain them.
+        const z3::sort& sort = phys_sort(element_kind);
+        auto [inserted_it, _] =
+            phys_read_fns_.emplace(element_kind, ctx.function(name.c_str(), sort, ctx.int_sort()));
+        return inserted_it->second;
+    }
+
+    const z3::func_decl& phys_write_fn(std::string_view element_kind)
+    {
+        auto it = phys_write_fns_.find(element_kind);
+        if (it != phys_write_fns_.end())
+        {
+            return it->second;
+        }
+        auto& ctx = solver_.context();
+        const std::string name = "phys_write_" + std::string(element_kind);
+        // phys_write : Phys<T> x Int -> Unit. No axioms relate it to read().
+        const z3::sort& sort = phys_sort(element_kind);
+        auto [inserted_it, _] = phys_write_fns_.emplace(
+            element_kind, ctx.function(name.c_str(), sort, ctx.int_sort(), ctx.int_sort()));
+        return inserted_it->second;
+    }
+
+    std::optional<std::string_view> lookup_phys_var(std::string_view name)
+    {
+        if (auto it = phys_vars_.find(name); it != phys_vars_.end())
+        {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+    bool pred_mentions_opaque_read(const curlee::parser::Pred& pred) const
+    {
+        bool found = false;
+        std::visit(
+            [&](const auto& node)
+            {
+                using Node = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<Node, curlee::parser::PredName>)
+                {
+                    if (opaque_read_vars_.count(node.name) != 0)
+                    {
+                        found = true;
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PredUnary>)
+                {
+                    if (node.rhs != nullptr && pred_mentions_opaque_read(*node.rhs))
+                    {
+                        found = true;
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PredBinary>)
+                {
+                    if (node.lhs != nullptr && pred_mentions_opaque_read(*node.lhs))
+                    {
+                        found = true;
+                    }
+                    if (node.rhs != nullptr && pred_mentions_opaque_read(*node.rhs))
+                    {
+                        found = true;
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PredGroup>)
+                {
+                    if (node.inner != nullptr && pred_mentions_opaque_read(*node.inner))
+                    {
+                        found = true;
+                    }
+                }
+            },
+            pred.node);
+        return found;
+    }
+
+    // Resolve the element kind name of a Phys base expression: either a NameExpr bound to a
+    // Phys<T> variable, or a direct PhysExpr literal.
+    std::string_view base_phys_element_kind(const Expr& base)
+    {
+        if (const auto* name = std::get_if<NameExpr>(&base.node))
+        {
+            if (auto found = lookup_phys_var(name->name); found.has_value())
+            {
+                return *found;
+            }
+            return {};
+        }
+        if (const auto* phys = std::get_if<curlee::parser::PhysExpr>(&base.node))
+        {
+            return phys->element_kind;
+        }
+        return {};
+    }
+
     void add_fact(const curlee::parser::Pred& pred)
     {
         auto lowered = lower_predicate(pred, lower_ctx_);
         if (std::holds_alternative<Diagnostic>(lowered))
         {
-            diags_.push_back(std::get<Diagnostic>(std::move(lowered)));
+            auto d = std::get<Diagnostic>(std::move(lowered));
+            if (pred_mentions_opaque_read(pred))
+            {
+                Related note;
+                note.message = "MMIO read is opaque; cannot prove this contract";
+                note.span = std::nullopt;
+                d.notes.push_back(std::move(note));
+            }
+            diags_.push_back(std::move(d));
             return;
         }
         facts_.push_back(std::get<z3::expr>(lowered));
@@ -527,6 +709,87 @@ class Verifier
                     }
 
                     return error_at(e.span, "unsupported binary operator in expression");
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PhysExpr>)
+                {
+                    // Second-line enforcement: the address must be a constant literal.
+                    // The front-end guarantees this, but the verifier does not trust the AST.
+                    if (!is_phys_address_literal(node.lexeme))
+                    {
+                        return error_at(e.span, "physical address must be a constant literal");
+                    }
+                    const auto elem_kind =
+                        curlee::types::phys_element_kind_from_name(node.element_kind);
+                    if (!elem_kind.has_value())
+                    {
+                        return error_at(e.span, "unsupported Phys element kind '" +
+                                                    std::string(node.element_kind) + "'");
+                    }
+                    // Lower to a constant of the opaque sort. The constant name embeds the
+                    // element kind and the address lexeme so distinct addresses stay distinct.
+                    const std::string const_name = "phys_" + std::string(node.element_kind) + "_" +
+                                                   std::string(node.lexeme);
+                    const z3::sort& sort = phys_sort(node.element_kind);
+                    return ExprValue{solver_.context().constant(const_name.c_str(), sort),
+                                     TypeKind::Phys, true};
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PhysReadExpr>)
+                {
+                    // read() lowers to the uninterpreted function phys_read : Phys<T> -> T.
+                    // No axioms constrain it, so the returned value is opaque to the solver.
+                    if (node.base == nullptr) // GCOVR_EXCL_LINE
+                    {
+                        return error_at(e.span, "missing Phys base in read()"); // GCOVR_EXCL_LINE
+                    }
+                    auto base_res = lower_expr(*node.base);
+                    if (std::holds_alternative<Diagnostic>(base_res))
+                    {
+                        return std::get<Diagnostic>(base_res);
+                    }
+                    auto base = std::get<ExprValue>(base_res);
+                    if (base.kind != TypeKind::Phys)
+                    {
+                        return error_at(e.span, "read() can only be called on a Phys<T> value");
+                    }
+                    const std::string_view elem = base_phys_element_kind(*node.base);
+                    if (elem.empty())
+                    {
+                        return error_at(e.span, "cannot determine Phys element kind");
+                    }
+                    return ExprValue{phys_read_fn(elem)(base.expr), TypeKind::Int, false};
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PhysWriteExpr>)
+                {
+                    // write(v) lowers to the uninterpreted function phys_write : Phys<T> x T ->
+                    // Unit. No axioms relate it to read(), so writes are opaque too.
+                    if (node.base == nullptr || node.value == nullptr) // GCOVR_EXCL_LINE
+                    {
+                        return error_at(e.span, "missing Phys base or value in write()"); // GCOVR_EXCL_LINE
+                    }
+                    auto base_res = lower_expr(*node.base);
+                    if (std::holds_alternative<Diagnostic>(base_res))
+                    {
+                        return std::get<Diagnostic>(base_res);
+                    }
+                    auto base = std::get<ExprValue>(base_res);
+                    if (base.kind != TypeKind::Phys)
+                    {
+                        return error_at(e.span, "write() can only be called on a Phys<T> value");
+                    }
+                    auto value_res = lower_expr(*node.value);
+                    if (std::holds_alternative<Diagnostic>(value_res))
+                    {
+                        return std::get<Diagnostic>(value_res);
+                    }
+                    auto value = std::get<ExprValue>(value_res);
+                    const std::string_view elem = base_phys_element_kind(*node.base);
+                    if (elem.empty())
+                    {
+                        return error_at(e.span, "cannot determine Phys element kind");
+                    }
+                    // Unit result: represent with a dummy Bool true (Unit is not a Z3 sort).
+                    (void)phys_write_fn(elem)(base.expr, value.expr);
+                    return ExprValue{solver_.context().bool_val(true), TypeKind::Unit, false};
                 }
                 else if constexpr (std::is_same_v<Node, CallExpr>)
                 {
@@ -682,7 +945,15 @@ class Verifier
             auto lowered = lower_predicate(req, call_ctx);
             if (std::holds_alternative<Diagnostic>(lowered))
             {
-                diags_.push_back(std::get<Diagnostic>(std::move(lowered)));
+                auto d = std::get<Diagnostic>(std::move(lowered));
+                if (pred_mentions_opaque_read(req))
+                {
+                    Related note;
+                    note.message = "MMIO read is opaque; cannot prove this contract";
+                    note.span = std::nullopt;
+                    d.notes.push_back(std::move(note));
+                }
+                diags_.push_back(std::move(d));
                 continue;
             }
 
@@ -829,7 +1100,15 @@ class Verifier
             auto lowered_pred = lower_predicate(ens, ensure_ctx);
             if (std::holds_alternative<Diagnostic>(lowered_pred))
             {
-                diags_.push_back(std::get<Diagnostic>(std::move(lowered_pred)));
+                auto d = std::get<Diagnostic>(std::move(lowered_pred));
+                if (pred_mentions_opaque_read(ens))
+                {
+                    Related note;
+                    note.message = "MMIO read is opaque; cannot prove this contract";
+                    note.span = std::nullopt;
+                    d.notes.push_back(std::move(note));
+                }
+                diags_.push_back(std::move(d));
                 continue;
             }
 
@@ -849,6 +1128,29 @@ class Verifier
         // Verification scope only reasons about Int/Bool values.
         // Non-scalar bindings (e.g. structs/enums) are allowed as long as we don't
         // attach refinements to them, since we can't lower them into the solver.
+
+        // A Phys<T> binding names an opaque pointer value. Record its element kind so that
+        // read()/write() can be lowered as uninterpreted functions.
+        if (s.type.name == "Phys")
+        {
+            if (s.type.type_arg.has_value())
+            {
+                phys_vars_.insert_or_assign(s.name, *s.type.type_arg);
+            }
+            // Re-validate the address is a constant literal inside the verifier (defense in
+            // depth: the front-end enforces this, but the verifier must not trust the AST).
+            if (const auto* phys = std::get_if<curlee::parser::PhysExpr>(&s.value.node))
+            {
+                if (!is_phys_address_literal(phys->lexeme))
+                {
+                    diags_.push_back(
+                        error_at(s.value.span, "physical address must be a constant literal"));
+                }
+            }
+            check_expr_for_calls(s.value);
+            return;
+        }
+
         const auto core_t = curlee::types::core_type_from_name(s.type.name);
         if (!core_t.has_value())
         {
@@ -878,6 +1180,24 @@ class Verifier
         if (is_phys_element_kind(core_t->kind))
         {
             // Uninterpreted: do not declare a solver variable, but still scan for calls.
+            // If the value comes from a Phys read(), the binding is an opaque value that
+            // contracts cannot depend on.
+            if (std::holds_alternative<curlee::parser::PhysReadExpr>(s.value.node))
+            {
+                opaque_read_vars_.insert(s.name);
+            }
+            // A refinement on an opaque read value cannot be proven; surface it as a hard
+            // diagnostic with the opaque-value note rather than silently passing.
+            if (s.refinement.has_value() && pred_mentions_opaque_read(*s.refinement))
+            {
+                auto d = error_at(s.refinement->span,
+                                  "cannot prove refinement on opaque MMIO read value");
+                Related note;
+                note.message = "MMIO read is opaque; cannot prove this contract";
+                note.span = std::nullopt;
+                d.notes.push_back(std::move(note));
+                diags_.push_back(std::move(d));
+            }
             check_expr_for_calls(s.value);
             return;
         }
@@ -1026,6 +1346,8 @@ class Verifier
         lower_ctx_.result_bool.reset();
         lower_ctx_.int_vars.clear();
         lower_ctx_.bool_vars.clear();
+        phys_vars_.clear();
+        opaque_read_vars_.clear();
         facts_.clear();
         scopes_.clear();
 
@@ -1034,6 +1356,14 @@ class Verifier
         {
             const auto& param = f.params[i];
             const auto param_kind = sig_it->second.params[i];
+
+            // Phys<T> parameters are opaque pointers; record their element kind so that
+            // read()/write() on the parameter can be lowered.
+            if (param_kind == TypeKind::Phys && param.type.type_arg.has_value())
+            {
+                phys_vars_.insert_or_assign(param.name, *param.type.type_arg);
+            }
+
             declare_var(param.name, param_kind);
 
             if (param.refinement.has_value())

--- a/src/verification/checker.cpp
+++ b/src/verification/checker.cpp
@@ -332,7 +332,8 @@ class Verifier
             return std::nullopt;
         }
 
-        if (t->kind == TypeKind::Int || t->kind == TypeKind::Bool || t->kind == TypeKind::Unit)
+        if (t->kind == TypeKind::Int || t->kind == TypeKind::Bool || t->kind == TypeKind::Unit ||
+            is_phys_element_kind(t->kind))
         {
             return t->kind;
         }
@@ -524,6 +525,51 @@ class Verifier
         return found;
     }
 
+    // True if a predicate mentions the special `result` symbol.
+    bool pred_mentions_result(const curlee::parser::Pred& pred) const
+    {
+        bool found = false;
+        std::visit(
+            [&](const auto& node)
+            {
+                using Node = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<Node, curlee::parser::PredName>)
+                {
+                    if (node.name == "result")
+                    {
+                        found = true;
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PredUnary>)
+                {
+                    if (node.rhs != nullptr && pred_mentions_result(*node.rhs))
+                    {
+                        found = true;
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PredBinary>)
+                {
+                    if (node.lhs != nullptr && pred_mentions_result(*node.lhs))
+                    {
+                        found = true;
+                    }
+                    if (node.rhs != nullptr && pred_mentions_result(*node.rhs))
+                    {
+                        found = true;
+                    }
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::PredGroup>)
+                {
+                    if (node.inner != nullptr && pred_mentions_result(*node.inner))
+                    {
+                        found = true;
+                    }
+                }
+            },
+            pred.node);
+        return found;
+    }
+
     // Resolve the element kind name of a Phys base expression: either a NameExpr bound to a
     // Phys<T> variable, or a direct PhysExpr literal.
     std::string_view base_phys_element_kind(const Expr& base)
@@ -543,20 +589,74 @@ class Verifier
         return {};
     }
 
+    // True if an expression derives from an opaque MMIO read, transitively. A value is opaque
+    // if it is a PhysReadExpr, or a NameExpr bound to an opaque read (directly or via aliases),
+    // or a compound expression containing one.
+    bool expr_is_opaque_read(const Expr& e) const
+    {
+        return std::visit(
+            [&](const auto& node) -> bool
+            {
+                using Node = std::decay_t<decltype(node)>;
+                if constexpr (std::is_same_v<Node, curlee::parser::PhysReadExpr>)
+                {
+                    return true;
+                }
+                else if constexpr (std::is_same_v<Node, NameExpr>)
+                {
+                    return opaque_read_vars_.count(node.name) != 0;
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::GroupExpr>)
+                {
+                    return node.inner != nullptr && expr_is_opaque_read(*node.inner);
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::UnaryExpr>)
+                {
+                    return node.rhs != nullptr && expr_is_opaque_read(*node.rhs);
+                }
+                else if constexpr (std::is_same_v<Node, curlee::parser::BinaryExpr>)
+                {
+                    if (node.lhs != nullptr && expr_is_opaque_read(*node.lhs))
+                    {
+                        return true;
+                    }
+                    return node.rhs != nullptr && expr_is_opaque_read(*node.rhs);
+                }
+                return false;
+            },
+            e.node);
+    }
+
+    void add_opaque_read_note(Diagnostic& d)
+    {
+        Related note;
+        note.message = "MMIO read is opaque; cannot prove this contract";
+        note.span = std::nullopt;
+        d.notes.push_back(std::move(note));
+    }
+
+    // Hard diagnostic for a contract that mentions an opaque MMIO read value. The build must
+    // fail rather than silently accept an unprovable contract.
+    void reject_opaque_read_contract(Span span, std::string_view message)
+    {
+        auto d = error_at(span, std::string(message));
+        add_opaque_read_note(d);
+        diags_.push_back(std::move(d));
+    }
+
     void add_fact(const curlee::parser::Pred& pred)
     {
+        // Opaque MMIO read values can never satisfy a contract: reject unconditionally
+        // before attempting to lower, so no opaque-derived contract can silently pass.
+        if (pred_mentions_opaque_read(pred))
+        {
+            reject_opaque_read_contract(pred.span, "cannot prove contract on opaque MMIO read value");
+            return;
+        }
         auto lowered = lower_predicate(pred, lower_ctx_);
         if (std::holds_alternative<Diagnostic>(lowered))
         {
-            auto d = std::get<Diagnostic>(std::move(lowered));
-            if (pred_mentions_opaque_read(pred))
-            {
-                Related note;
-                note.message = "MMIO read is opaque; cannot prove this contract";
-                note.span = std::nullopt;
-                d.notes.push_back(std::move(note));
-            }
-            diags_.push_back(std::move(d));
+            diags_.push_back(std::get<Diagnostic>(std::move(lowered)));
             return;
         }
         facts_.push_back(std::get<z3::expr>(lowered));
@@ -888,11 +988,33 @@ class Verifier
             return;
         }
 
+        // An opaque MMIO read value must never flow into a contract silently. Check argument
+        // provenance before the MVP gate so that a call like consume(reg.read()) with a
+        // requires-guarded unsigned parameter is a hard error, not a silent skip.
+        bool arg_is_opaque = false;
+        for (const auto& arg : call.args)
+        {
+            if (expr_is_opaque_read(arg))
+            {
+                arg_is_opaque = true;
+                break;
+            }
+        }
+
         // MVP: only reason about calls whose arguments are entirely Int/Bool.
         for (const auto k : sig.params)
         {
             if (k != TypeKind::Int && k != TypeKind::Bool)
             {
+                // The callee has non-scalar parameters (e.g. unsigned element kinds). If an
+                // argument derives from an opaque MMIO read, any contract on that parameter
+                // cannot be proven - fail loudly instead of silently skipping.
+                if (arg_is_opaque)
+                {
+                    const Span span = call.args.empty() ? Span{} : call.args[0].span;
+                    reject_opaque_read_contract(span,
+                                                "cannot prove call contract on opaque MMIO read argument");
+                }
                 return;
             }
         }
@@ -942,18 +1064,18 @@ class Verifier
 
         for (const auto& req : sig.decl->requires_clauses)
         {
+            // A requires clause mentioning an opaque MMIO read value can never be proven;
+            // reject unconditionally before lowering.
+            if (pred_mentions_opaque_read(req))
+            {
+                reject_opaque_read_contract(req.span,
+                                            "cannot prove requires on opaque MMIO read value");
+                continue;
+            }
             auto lowered = lower_predicate(req, call_ctx);
             if (std::holds_alternative<Diagnostic>(lowered))
             {
-                auto d = std::get<Diagnostic>(std::move(lowered));
-                if (pred_mentions_opaque_read(req))
-                {
-                    Related note;
-                    note.message = "MMIO read is opaque; cannot prove this contract";
-                    note.span = std::nullopt;
-                    d.notes.push_back(std::move(note));
-                }
-                diags_.push_back(std::move(d));
+                diags_.push_back(std::get<Diagnostic>(std::move(lowered)));
                 continue;
             }
 
@@ -1073,8 +1195,30 @@ class Verifier
         }
 
         auto value = std::get<ExprValue>(lowered);
-        if (value.kind != expected_return)
+        // An opaque MMIO read lowers to an Int-typed Z3 term; accept it for unsigned element
+        // kind returns (U8/U16/U32/U64) so the ensures check can run below.
+        const bool opaque_unsigned_return =
+            is_phys_element_kind(expected_return) && value.kind == TypeKind::Int &&
+            expr_is_opaque_read(*s.value);
+        if (value.kind != expected_return && !opaque_unsigned_return)
         {
+            return;
+        }
+
+        // A function returning an opaque MMIO read value has an unprovable `result`: any
+        // ensures clause mentioning it must be rejected with the opaque note, never silently
+        // satisfied.
+        const bool result_is_opaque = expr_is_opaque_read(*s.value);
+        if (result_is_opaque)
+        {
+            for (const auto& ens : func->ensures)
+            {
+                if (pred_mentions_result(ens))
+                {
+                    reject_opaque_read_contract(ens.span,
+                                                "cannot prove ensures on opaque MMIO read result");
+                }
+            }
             return;
         }
 
@@ -1100,15 +1244,7 @@ class Verifier
             auto lowered_pred = lower_predicate(ens, ensure_ctx);
             if (std::holds_alternative<Diagnostic>(lowered_pred))
             {
-                auto d = std::get<Diagnostic>(std::move(lowered_pred));
-                if (pred_mentions_opaque_read(ens))
-                {
-                    Related note;
-                    note.message = "MMIO read is opaque; cannot prove this contract";
-                    note.span = std::nullopt;
-                    d.notes.push_back(std::move(note));
-                }
-                diags_.push_back(std::move(d));
+                diags_.push_back(std::get<Diagnostic>(std::move(lowered_pred)));
                 continue;
             }
 
@@ -1180,9 +1316,11 @@ class Verifier
         if (is_phys_element_kind(core_t->kind))
         {
             // Uninterpreted: do not declare a solver variable, but still scan for calls.
-            // If the value comes from a Phys read(), the binding is an opaque value that
-            // contracts cannot depend on.
-            if (std::holds_alternative<curlee::parser::PhysReadExpr>(s.value.node))
+            // Opaque provenance is transitive: a binding whose initializer derives from a
+            // Phys read() (directly or via an alias chain) is itself opaque and must not be
+            // contractable.
+            if (std::holds_alternative<curlee::parser::PhysReadExpr>(s.value.node) ||
+                expr_is_opaque_read(s.value))
             {
                 opaque_read_vars_.insert(s.name);
             }
@@ -1190,13 +1328,8 @@ class Verifier
             // diagnostic with the opaque-value note rather than silently passing.
             if (s.refinement.has_value() && pred_mentions_opaque_read(*s.refinement))
             {
-                auto d = error_at(s.refinement->span,
-                                  "cannot prove refinement on opaque MMIO read value");
-                Related note;
-                note.message = "MMIO read is opaque; cannot prove this contract";
-                note.span = std::nullopt;
-                d.notes.push_back(std::move(note));
-                diags_.push_back(std::move(d));
+                reject_opaque_read_contract(s.refinement->span,
+                                            "cannot prove refinement on opaque MMIO read value");
             }
             check_expr_for_calls(s.value);
             return;
@@ -1362,6 +1495,14 @@ class Verifier
             if (param_kind == TypeKind::Phys && param.type.type_arg.has_value())
             {
                 phys_vars_.insert_or_assign(param.name, *param.type.type_arg);
+            }
+
+            // Unsigned element-kind parameters are opaque: a refinement/requires on them
+            // cannot be proven, so mark them opaque to route any such contract to the hard
+            // opaque-read diagnostic.
+            if (is_phys_element_kind(param_kind))
+            {
+                opaque_read_vars_.insert(param.name);
             }
 
             declare_var(param.name, param_kind);

--- a/src/verification/checker.cpp
+++ b/src/verification/checker.cpp
@@ -1011,8 +1011,9 @@ class Verifier
                 // cannot be proven - fail loudly instead of silently skipping.
                 if (arg_is_opaque)
                 {
-                    const Span span = call.args.empty() ? Span{} : call.args[0].span;
-                    reject_opaque_read_contract(span,
+                    // arg_is_opaque is only set when an argument was scanned, so args is
+                    // guaranteed non-empty here (the ternary fallback was dead code).
+                    reject_opaque_read_contract(call.args[0].span,
                                                 "cannot prove call contract on opaque MMIO read argument");
                 }
                 return;

--- a/tests/cli_diagnostics/check_phys_read_contract.golden
+++ b/tests/cli_diagnostics/check_phys_read_contract.golden
@@ -1,0 +1,5 @@
+tests/fixtures/check_phys_read_contract.curlee:4:22: error: cannot prove refinement on opaque MMIO read value
+  |
+  |     let v: U32 where v > 0 = reg.read();
+  |                      ^^^^^
+note: MMIO read is opaque; cannot prove this contract

--- a/tests/cli_diagnostics/check_phys_read_requires.golden
+++ b/tests/cli_diagnostics/check_phys_read_requires.golden
@@ -1,0 +1,10 @@
+tests/fixtures/check_phys_read_requires.curlee:2:12: error: cannot prove contract on opaque MMIO read value
+  |
+  |   requires x > 0;
+  |            ^^^^^
+note: MMIO read is opaque; cannot prove this contract
+tests/fixtures/check_phys_read_requires.curlee:11:20: error: cannot prove call contract on opaque MMIO read argument
+  |
+  |     return consume(v);
+  |                    ^
+note: MMIO read is opaque; cannot prove this contract

--- a/tests/cli_diagnostics_golden_tests.cpp
+++ b/tests/cli_diagnostics_golden_tests.cpp
@@ -898,6 +898,10 @@ int main(int argc, char** argv)
     const fs::path rel_type_error = fs::path("tests/fixtures/check_type_error.curlee");
     const fs::path rel_struct_ok = fs::path("tests/fixtures/check_struct_ok.curlee");
     const fs::path rel_ensures_fail = fs::path("tests/fixtures/check_ensures_fail.curlee");
+    const fs::path rel_phys_framebuffer =
+        fs::path("tests/fixtures/check_phys_framebuffer.curlee");
+    const fs::path rel_phys_read_contract =
+        fs::path("tests/fixtures/check_phys_read_contract.curlee");
     const fs::path rel_phys_mem_ok = fs::path("tests/fixtures/check_phys_mem_ok.curlee");
     const fs::path rel_phys_non_literal_addr =
         fs::path("tests/fixtures/check_phys_non_literal_addr.curlee");
@@ -1086,6 +1090,25 @@ int main(int argc, char** argv)
         if (!run_stderr_case("check-phys-read-non-phys",
                              {"curlee", "check", rel_phys_read_non_phys.string()},
                              dir / "check_phys_read_non_phys.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        // Verifier: trusted/opaque Phys<T> deref semantics (issue #253). The positive
+        // framebuffer fixture must pass with zero obligations; the read-contract fixture must
+        // fail with the opaque-value note.
+        if (!run_stderr_case("check-phys-framebuffer",
+                             {"curlee", "check", rel_phys_framebuffer.string()},
+                             dir / "check_phys_framebuffer.golden",
+                             true))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-read-contract",
+                             {"curlee", "check", rel_phys_read_contract.string()},
+                             dir / "check_phys_read_contract.golden",
                              false))
         {
             return 1;

--- a/tests/cli_diagnostics_golden_tests.cpp
+++ b/tests/cli_diagnostics_golden_tests.cpp
@@ -902,6 +902,8 @@ int main(int argc, char** argv)
         fs::path("tests/fixtures/check_phys_framebuffer.curlee");
     const fs::path rel_phys_read_contract =
         fs::path("tests/fixtures/check_phys_read_contract.curlee");
+    const fs::path rel_phys_read_requires =
+        fs::path("tests/fixtures/check_phys_read_requires.curlee");
     const fs::path rel_phys_mem_ok = fs::path("tests/fixtures/check_phys_mem_ok.curlee");
     const fs::path rel_phys_non_literal_addr =
         fs::path("tests/fixtures/check_phys_non_literal_addr.curlee");
@@ -1109,6 +1111,14 @@ int main(int argc, char** argv)
         if (!run_stderr_case("check-phys-read-contract",
                              {"curlee", "check", rel_phys_read_contract.string()},
                              dir / "check_phys_read_contract.golden",
+                             false))
+        {
+            return 1;
+        }
+
+        if (!run_stderr_case("check-phys-read-requires",
+                             {"curlee", "check", rel_phys_read_requires.string()},
+                             dir / "check_phys_read_requires.golden",
                              false))
         {
             return 1;

--- a/tests/fixtures/check_phys_framebuffer.curlee
+++ b/tests/fixtures/check_phys_framebuffer.curlee
@@ -1,0 +1,8 @@
+fn main(pm: cap phys.mem) -> Unit {
+  unsafe {
+    let fb: Phys<U32> = phys<U32>(0xFD00_0000); // framebuffer base
+    fb.write(0xFF8800);                          // pixel write
+    let v: U32 = fb.read();                      // register/framebuffer read
+  }
+  return;
+}

--- a/tests/fixtures/check_phys_read_contract.curlee
+++ b/tests/fixtures/check_phys_read_contract.curlee
@@ -1,0 +1,7 @@
+fn main(pm: cap phys.mem) -> Int {
+  unsafe {
+    let reg: Phys<U32> = phys<U32>(0xFE00_0000);
+    let v: U32 where v > 0 = reg.read();
+  }
+  return 0;
+}

--- a/tests/fixtures/check_phys_read_requires.curlee
+++ b/tests/fixtures/check_phys_read_requires.curlee
@@ -1,0 +1,13 @@
+fn consume(x: U32) -> Int [
+  requires x > 0;
+] {
+  return 0;
+}
+
+fn main(pm: cap phys.mem) -> Int {
+  unsafe {
+    let reg: Phys<U32> = phys<U32>(0xFE00_0000);
+    let v: U32 = reg.read();
+    return consume(v);
+  }
+}

--- a/tests/types_extra_tests.cpp
+++ b/tests/types_extra_tests.cpp
@@ -1478,7 +1478,8 @@ fn main(v: E) -> Unit {
             "variant_is expects enum variant tag as second argument");
 
         expect_diag(
-            run_tc("enum E { A(Int); } enum F { A(Int); } fn main() -> Bool { let e: E = E::A(1); return variant_is(e, F::A); }"),
+            run_tc("enum E { A(Int); } enum F { A(Int); } fn main() -> Bool { "
+                   "let e: E = E::A(1); return variant_is(e, F::A); }"),
             "variant_is enum mismatch between value and variant tag");
 
         expect_diag(
@@ -1489,7 +1490,8 @@ fn main(v: E) -> Unit {
                     "variant_unwrap expects exactly 2 argument");
 
         expect_diag(
-            run_tc("enum E { A(Int); } enum F { A(Int); } fn main() -> Int { let e: E = E::A(1); return variant_unwrap(e, F::A); }"),
+            run_tc("enum E { A(Int); } enum F { A(Int); } fn main() -> Int { "
+                   "let e: E = E::A(1); return variant_unwrap(e, F::A); }"),
             "variant_unwrap enum mismatch between value and variant tag");
 
         expect_diag(

--- a/tests/verification_checker_internal_tests.ipp
+++ b/tests/verification_checker_internal_tests.ipp
@@ -1458,6 +1458,645 @@ int main()
     }
 
     {
+        // is_phys_address_literal: empty lexeme -> false (line 208).
+        if (curlee::verification::is_phys_address_literal(""))
+        {
+            fail("expected is_phys_address_literal(empty) to be false");
+        }
+        if (!curlee::verification::is_phys_address_literal("0xFD00_0000"))
+        {
+            fail("expected is_phys_address_literal(hex) to be true");
+        }
+        if (!curlee::verification::is_phys_address_literal("4096"))
+        {
+            fail("expected is_phys_address_literal(decimal) to be true");
+        }
+        if (curlee::verification::is_phys_address_literal("base"))
+        {
+            fail("expected is_phys_address_literal(name) to be false");
+        }
+
+        // phys_sort cache-hit path (line 464).
+        const curlee::source::Span s_cov{.start = 0, .end = 1};
+        v.phys_sorts_.clear();
+        const auto& s1 = v.phys_sort("U32");
+        const auto& s2 = v.phys_sort("U32");
+        if (s1.id() != s2.id())
+        {
+            fail("expected phys_sort to return the same cached sort");
+        }
+        v.phys_sorts_.clear();
+
+        // phys_read_fn cache-hit path (line 464): calling twice returns the cached decl.
+        v.phys_read_fns_.clear();
+        const auto& rf1 = v.phys_read_fn("U32");
+        const auto& rf2 = v.phys_read_fn("U32");
+        if (rf1.id() != rf2.id())
+        {
+            fail("expected phys_read_fn to return the same cached decl");
+        }
+        v.phys_read_fns_.clear();
+
+        // phys_write_fn cache-hit path (line 464): calling twice returns the cached decl.
+        v.phys_write_fns_.clear();
+        const auto& wf1 = v.phys_write_fn("U32");
+        const auto& wf2 = v.phys_write_fn("U32");
+        if (wf1.id() != wf2.id())
+        {
+            fail("expected phys_write_fn to return the same cached decl");
+        }
+        v.phys_write_fns_.clear();
+
+        // lookup_phys_var not-found path (line 481).
+        if (v.lookup_phys_var("no_such_phys_var").has_value())
+        {
+            fail("expected lookup_phys_var(unknown) to be nullopt");
+        }
+    }
+
+    {
+        // pred_mentions_opaque_read recursion paths (unary/binary/group with opaque names).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        v.opaque_read_vars_.insert("op");
+
+        auto p_unary = make_pred(
+            s, curlee::parser::PredUnary{
+                   .op = curlee::lexer::TokenKind::Bang,
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "op"}))});
+        if (!v.pred_mentions_opaque_read(p_unary))
+        {
+            fail("expected pred_mentions_opaque_read(!op) to be true");
+        }
+        auto p_unary_plain = make_pred(
+            s, curlee::parser::PredUnary{
+                   .op = curlee::lexer::TokenKind::Bang,
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "x"}))});
+        if (v.pred_mentions_opaque_read(p_unary_plain))
+        {
+            fail("expected pred_mentions_opaque_read(!x) to be false");
+        }
+        auto p_bin_lhs = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "op"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        if (!v.pred_mentions_opaque_read(p_bin_lhs))
+        {
+            fail("expected pred_mentions_opaque_read(op > 0) to be true");
+        }
+        auto p_bin_rhs = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "op"}))});
+        if (!v.pred_mentions_opaque_read(p_bin_rhs))
+        {
+            fail("expected pred_mentions_opaque_read(0 < op) to be true");
+        }
+        auto p_group = make_pred(
+            s, curlee::parser::PredGroup{
+                   .inner = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "op"}))});
+        if (!v.pred_mentions_opaque_read(p_group))
+        {
+            fail("expected pred_mentions_opaque_read((op)) to be true");
+        }
+        v.opaque_read_vars_.clear();
+    }
+
+    {
+        // base_phys_element_kind paths: NameExpr not a phys var, direct PhysExpr, and default.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        v.phys_vars_.insert_or_assign("fb_base", std::string_view("U32"));
+
+        curlee::parser::Expr name_ok;
+        name_ok.span = s;
+        name_ok.node = curlee::parser::NameExpr{.name = "fb_base"};
+        if (v.base_phys_element_kind(name_ok) != "U32")
+        {
+            fail("expected base_phys_element_kind(NameExpr phys) to return element kind");
+        }
+
+        curlee::parser::Expr name_missing;
+        name_missing.span = s;
+        name_missing.node = curlee::parser::NameExpr{.name = "no_such"};
+        if (!v.base_phys_element_kind(name_missing).empty())
+        {
+            fail("expected base_phys_element_kind(NameExpr non-phys) to be empty");
+        }
+
+        curlee::parser::Expr phys_direct;
+        phys_direct.span = s;
+        phys_direct.node =
+            curlee::parser::PhysExpr{.element_kind = "U16", .lexeme = "0x1000"};
+        if (v.base_phys_element_kind(phys_direct) != "U16")
+        {
+            fail("expected base_phys_element_kind(PhysExpr) to return element kind");
+        }
+
+        curlee::parser::Expr other;
+        other.span = s;
+        other.node = curlee::parser::IntExpr{.lexeme = "1"};
+        if (!v.base_phys_element_kind(other).empty())
+        {
+            fail("expected base_phys_element_kind(IntExpr) to be empty");
+        }
+        v.phys_vars_.erase("fb_base");
+    }
+
+    {
+        // lower_expr(PhysExpr) with an unsupported element kind (lines 825-826).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Expr e_phys_badkind;
+        e_phys_badkind.span = s;
+        e_phys_badkind.node =
+            curlee::parser::PhysExpr{.element_kind = "String", .lexeme = "0x1000"};
+        auto r_badkind = v.lower_expr(e_phys_badkind);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_badkind))
+        {
+            fail("expected lower_expr(PhysExpr String kind) to error");
+        }
+
+        // lower_expr(PhysReadExpr) on a non-Phys base (line 852).
+        v.phys_vars_.insert_or_assign("fb_cov", std::string_view("U32"));
+        curlee::parser::Expr read_int_base;
+        read_int_base.span = s;
+        read_int_base.node = curlee::parser::IntExpr{.lexeme = "5"};
+        curlee::parser::Expr e_read_int;
+        e_read_int.span = s;
+        e_read_int.node = curlee::parser::PhysReadExpr{
+            .base = make_expr_ptr(std::move(read_int_base))};
+        auto r_read_int = v.lower_expr(e_read_int);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_read_int))
+        {
+            fail("expected lower_expr(PhysReadExpr on Int base) to error");
+        }
+
+        // lower_expr(PhysReadExpr) where element kind cannot be resolved (line 857): a
+        // GroupExpr wrapping a Phys name lowers to Phys kind, but base_phys_element_kind
+        // cannot extract the element kind through the group.
+        curlee::parser::Expr read_g_base;
+        read_g_base.span = s;
+        read_g_base.node = curlee::parser::NameExpr{.name = "fb_cov"};
+        curlee::parser::Expr read_group;
+        read_group.span = s;
+        read_group.node = curlee::parser::GroupExpr{.inner = make_expr_ptr(std::move(read_g_base))};
+        curlee::parser::Expr e_read_unk;
+        e_read_unk.span = s;
+        e_read_unk.node = curlee::parser::PhysReadExpr{
+            .base = make_expr_ptr(std::move(read_group))};
+        auto r_read_unk = v.lower_expr(e_read_unk);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_read_unk))
+        {
+            fail("expected lower_expr(PhysReadExpr unresolved kind) to error");
+        }
+
+        // lower_expr(PhysWriteExpr) on a non-Phys base (line 877).
+        curlee::parser::Expr write_int_base;
+        write_int_base.span = s;
+        write_int_base.node = curlee::parser::IntExpr{.lexeme = "5"};
+        curlee::parser::Expr write_val;
+        write_val.span = s;
+        write_val.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr e_write_int;
+        e_write_int.span = s;
+        e_write_int.node = curlee::parser::PhysWriteExpr{
+            .base = make_expr_ptr(std::move(write_int_base)),
+            .value = make_expr_ptr(std::move(write_val))};
+        auto r_write_int = v.lower_expr(e_write_int);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_write_int))
+        {
+            fail("expected lower_expr(PhysWriteExpr on Int base) to error");
+        }
+
+        // lower_expr(PhysWriteExpr) where the value lowering fails (line 882).
+        curlee::parser::Expr write_ok_base;
+        write_ok_base.span = s;
+        write_ok_base.node = curlee::parser::NameExpr{.name = "fb_cov"};
+        curlee::parser::Expr write_bad_val;
+        write_bad_val.span = s;
+        write_bad_val.node = curlee::parser::StringExpr{.lexeme = "\"x\""};
+        curlee::parser::Expr e_write_badval;
+        e_write_badval.span = s;
+        e_write_badval.node = curlee::parser::PhysWriteExpr{
+            .base = make_expr_ptr(std::move(write_ok_base)),
+            .value = make_expr_ptr(std::move(write_bad_val))};
+        auto r_write_badval = v.lower_expr(e_write_badval);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_write_badval))
+        {
+            fail("expected lower_expr(PhysWriteExpr bad value) to error");
+        }
+
+        // lower_expr(PhysWriteExpr) where element kind cannot be resolved (line 888): a
+        // GroupExpr-wrapped Phys name lowers to Phys kind but has no resolvable element kind.
+        curlee::parser::Expr write_g_base;
+        write_g_base.span = s;
+        write_g_base.node = curlee::parser::NameExpr{.name = "fb_cov"};
+        curlee::parser::Expr write_group;
+        write_group.span = s;
+        write_group.node = curlee::parser::GroupExpr{.inner = make_expr_ptr(std::move(write_g_base))};
+        curlee::parser::Expr write_val2;
+        write_val2.span = s;
+        write_val2.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr e_write_unk;
+        e_write_unk.span = s;
+        e_write_unk.node = curlee::parser::PhysWriteExpr{
+            .base = make_expr_ptr(std::move(write_group)),
+            .value = make_expr_ptr(std::move(write_val2))};
+        auto r_write_unk = v.lower_expr(e_write_unk);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_write_unk))
+        {
+            fail("expected lower_expr(PhysWriteExpr unresolved kind) to error");
+        }
+        v.phys_vars_.erase("fb_cov");
+    }
+
+    {
+        // check_function: Phys<T> parameter registration (line 1497).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f;
+        f.name = "phys_param_fn";
+        f.return_type = curlee::parser::TypeName{.span = s, .name = "Int"};
+        f.params.push_back(curlee::parser::Function::Param{
+            .span = s,
+            .name = "fb",
+            .type = curlee::parser::TypeName{.span = s, .name = "Phys", .type_arg = std::string_view("U32")},
+            .refinement = std::nullopt});
+        curlee::verification::FunctionSig sig;
+        sig.decl = &f;
+        sig.params = {curlee::types::TypeKind::Phys};
+        sig.result = curlee::types::TypeKind::Int;
+        v.functions_.insert_or_assign("phys_param_fn", sig);
+        // Exercise check_function's Phys-param registration branch. The scope is popped on
+        // return, so verify the branch ran by checking the parameter is registered while the
+        // body would be processed - here we just confirm the call does not emit a diagnostic
+        // for the Phys param and completes cleanly.
+        const std::size_t diags_before = v.diags_.size();
+        v.check_function(f);
+        if (v.diags_.size() != diags_before)
+        {
+            fail("expected check_function with Phys param to complete without diagnostics");
+        }
+        v.functions_.erase("phys_param_fn");
+    }
+
+    {
+        // Helper coverage: expr_is_opaque_read recursion paths and pred_mentions_result.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        v.opaque_read_vars_.insert("opaque_v");
+
+        // PhysReadExpr is opaque.
+        curlee::parser::Expr base_none;
+        base_none.span = s;
+        base_none.node = curlee::parser::PhysReadExpr{.base = nullptr};
+        if (!v.expr_is_opaque_read(base_none))
+        {
+            fail("expected expr_is_opaque_read(PhysReadExpr) to be true");
+        }
+
+        // NameExpr bound to an opaque read is opaque.
+        curlee::parser::Expr name_opaque;
+        name_opaque.span = s;
+        name_opaque.node = curlee::parser::NameExpr{.name = "opaque_v"};
+        if (!v.expr_is_opaque_read(name_opaque))
+        {
+            fail("expected expr_is_opaque_read(NameExpr opaque) to be true");
+        }
+
+        // Plain Int expr is not opaque.
+        curlee::parser::Expr int_plain;
+        int_plain.span = s;
+        int_plain.node = curlee::parser::IntExpr{.lexeme = "1"};
+        if (v.expr_is_opaque_read(int_plain))
+        {
+            fail("expected expr_is_opaque_read(IntExpr) to be false");
+        }
+
+        // GroupExpr wrapping an opaque name.
+        curlee::parser::Expr group_inner;
+        group_inner.span = s;
+        group_inner.node = curlee::parser::NameExpr{.name = "opaque_v"};
+        curlee::parser::Expr group;
+        group.span = s;
+        group.node = curlee::parser::GroupExpr{.inner = make_expr_ptr(std::move(group_inner))};
+        if (!v.expr_is_opaque_read(group))
+        {
+            fail("expected expr_is_opaque_read(GroupExpr opaque) to be true");
+        }
+
+        // GroupExpr with null inner.
+        curlee::parser::Expr group_null;
+        group_null.span = s;
+        group_null.node = curlee::parser::GroupExpr{.inner = nullptr};
+        if (v.expr_is_opaque_read(group_null))
+        {
+            fail("expected expr_is_opaque_read(GroupExpr null) to be false");
+        }
+
+        // UnaryExpr wrapping an opaque name.
+        curlee::parser::Expr unary_inner;
+        unary_inner.span = s;
+        unary_inner.node = curlee::parser::NameExpr{.name = "opaque_v"};
+        curlee::parser::Expr unary;
+        unary.span = s;
+        unary.node = curlee::parser::UnaryExpr{.op = curlee::lexer::TokenKind::Bang,
+                                               .rhs = make_expr_ptr(std::move(unary_inner))};
+        if (!v.expr_is_opaque_read(unary))
+        {
+            fail("expected expr_is_opaque_read(UnaryExpr opaque) to be true");
+        }
+
+        // UnaryExpr with null rhs.
+        curlee::parser::Expr unary_null;
+        unary_null.span = s;
+        unary_null.node = curlee::parser::UnaryExpr{.op = curlee::lexer::TokenKind::Bang,
+                                                    .rhs = nullptr};
+        if (v.expr_is_opaque_read(unary_null))
+        {
+            fail("expected expr_is_opaque_read(UnaryExpr null) to be false");
+        }
+
+        // BinaryExpr with opaque lhs / plain rhs.
+        curlee::parser::Expr bin_lhs;
+        bin_lhs.span = s;
+        bin_lhs.node = curlee::parser::NameExpr{.name = "opaque_v"};
+        curlee::parser::Expr bin_rhs;
+        bin_rhs.span = s;
+        bin_rhs.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr bin;
+        bin.span = s;
+        bin.node = curlee::parser::BinaryExpr{.op = curlee::lexer::TokenKind::Plus,
+                                              .lhs = make_expr_ptr(std::move(bin_lhs)),
+                                              .rhs = make_expr_ptr(std::move(bin_rhs))};
+        if (!v.expr_is_opaque_read(bin))
+        {
+            fail("expected expr_is_opaque_read(BinaryExpr opaque lhs) to be true");
+        }
+
+        // BinaryExpr with plain lhs / opaque rhs.
+        curlee::parser::Expr bin2_lhs;
+        bin2_lhs.span = s;
+        bin2_lhs.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr bin2_rhs;
+        bin2_rhs.span = s;
+        bin2_rhs.node = curlee::parser::NameExpr{.name = "opaque_v"};
+        curlee::parser::Expr bin2;
+        bin2.span = s;
+        bin2.node = curlee::parser::BinaryExpr{.op = curlee::lexer::TokenKind::Plus,
+                                               .lhs = make_expr_ptr(std::move(bin2_lhs)),
+                                               .rhs = make_expr_ptr(std::move(bin2_rhs))};
+        if (!v.expr_is_opaque_read(bin2))
+        {
+            fail("expected expr_is_opaque_read(BinaryExpr opaque rhs) to be true");
+        }
+
+        // BinaryExpr with null lhs.
+        curlee::parser::Expr bin3_rhs;
+        bin3_rhs.span = s;
+        bin3_rhs.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr bin3;
+        bin3.span = s;
+        bin3.node = curlee::parser::BinaryExpr{.op = curlee::lexer::TokenKind::Plus,
+                                               .lhs = nullptr,
+                                               .rhs = make_expr_ptr(std::move(bin3_rhs))};
+        if (v.expr_is_opaque_read(bin3))
+        {
+            fail("expected expr_is_opaque_read(BinaryExpr null lhs) to be false");
+        }
+
+        // pred_mentions_result: true for `result > 0`, false for `x > 0`.
+        auto p_result = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "result"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        if (!v.pred_mentions_result(p_result))
+        {
+            fail("expected pred_mentions_result(result > 0) to be true");
+        }
+        auto p_x = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "x"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        if (v.pred_mentions_result(p_x))
+        {
+            fail("expected pred_mentions_result(x > 0) to be false");
+        }
+        // pred_mentions_result: result on the rhs of a binary predicate (line 558).
+        auto p_result_rhs = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Less,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "result"}))});
+        if (!v.pred_mentions_result(p_result_rhs))
+        {
+            fail("expected pred_mentions_result(0 < result) to be true");
+        }
+        // pred_mentions_result: unary/group recursion paths.
+        auto p_not_result = make_pred(
+            s, curlee::parser::PredUnary{
+                   .op = curlee::lexer::TokenKind::Bang,
+                   .rhs = make_pred_ptr(
+                       make_pred(s, curlee::parser::PredName{.name = "result"}))});
+        if (!v.pred_mentions_result(p_not_result))
+        {
+            fail("expected pred_mentions_result(!result) to be true");
+        }
+        auto p_group_result = make_pred(
+            s, curlee::parser::PredGroup{
+                   .inner = make_pred_ptr(
+                       make_pred(s, curlee::parser::PredName{.name = "result"}))});
+        if (!v.pred_mentions_result(p_group_result))
+        {
+            fail("expected pred_mentions_result((result)) to be true");
+        }
+
+        v.opaque_read_vars_.clear();
+    }
+
+    {
+        // reject_opaque_read_contract / add_opaque_read_note: emit diagnostic with the note.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        const std::size_t before = v.diags_.size();
+        v.reject_opaque_read_contract(s, "cannot prove opaque");
+        if (v.diags_.size() != before + 1)
+        {
+            fail("expected reject_opaque_read_contract to emit one diagnostic");
+        }
+        bool saw_note = false;
+        for (const auto& n : v.diags_.back().notes)
+        {
+            if (n.message.find("MMIO read is opaque") != std::string::npos)
+            {
+                saw_note = true;
+            }
+        }
+        if (!saw_note)
+        {
+            fail("expected reject_opaque_read_contract to attach the opaque note");
+        }
+    }
+
+    {
+        // add_fact: opaque-read mention is rejected unconditionally (before lowering).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        v.opaque_read_vars_.insert("opaque_fact");
+        auto pred_opaque = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(
+                       make_pred(s, curlee::parser::PredName{.name = "opaque_fact"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        const std::size_t before = v.diags_.size();
+        v.add_fact(pred_opaque);
+        if (v.diags_.size() == before)
+        {
+            fail("expected add_fact to reject an opaque-read fact");
+        }
+        if (v.diags_.back().message.find("opaque MMIO read") == std::string::npos)
+        {
+            fail("expected add_fact opaque diagnostic message");
+        }
+        v.opaque_read_vars_.clear();
+    }
+
+    {
+        // check_call: opaque argument to a callee with an unsigned param is rejected before
+        // the Int/Bool-only gate (review gap #1).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function decl;
+        decl.name = "opaque_consume";
+        decl.return_type = curlee::parser::TypeName{.span = s, .name = "Int"};
+        decl.params.push_back(curlee::parser::Function::Param{
+            .span = s,
+            .name = "x",
+            .type = curlee::parser::TypeName{.span = s, .name = "U32"},
+            .refinement = std::nullopt});
+        curlee::verification::FunctionSig sig;
+        sig.decl = &decl;
+        sig.params = {curlee::types::TypeKind::U32};
+        sig.result = curlee::types::TypeKind::Int;
+        v.functions_.insert_or_assign("opaque_consume", sig);
+
+        curlee::parser::Expr arg;
+        arg.span = s;
+        arg.node = curlee::parser::PhysReadExpr{.base = nullptr};
+        curlee::parser::CallExpr call;
+        call.callee = make_expr_ptr(make_expr(s, curlee::parser::NameExpr{.name = "opaque_consume"}));
+        call.args.push_back(std::move(arg));
+        const std::size_t before = v.diags_.size();
+        v.check_call(call);
+        bool saw = false;
+        for (std::size_t i = before; i < v.diags_.size(); ++i)
+        {
+            if (v.diags_[i].message.find("opaque MMIO read") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected check_call to reject opaque read argument on unsigned param");
+        }
+        v.functions_.erase("opaque_consume");
+    }
+
+    {
+        // check_call: the requires-loop guard rejects a requires clause that mentions an
+        // opaque read name (line 1071). The callee's requires references a name that the
+        // caller has marked opaque.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function decl;
+        decl.name = "opaque_req_callee";
+        decl.return_type = curlee::parser::TypeName{.span = s, .name = "Int"};
+        decl.params.push_back(curlee::parser::Function::Param{
+            .span = s,
+            .name = "x",
+            .type = curlee::parser::TypeName{.span = s, .name = "Int"},
+            .refinement = std::nullopt});
+        decl.requires_clauses.push_back(make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "x"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))}));
+        curlee::verification::FunctionSig sig;
+        sig.decl = &decl;
+        sig.params = {curlee::types::TypeKind::Int};
+        sig.result = curlee::types::TypeKind::Int;
+        v.functions_.insert_or_assign("opaque_req_callee", sig);
+
+        // Mark `x` opaque in the caller scope so the requires clause `x > 0` triggers the
+        // unconditional rejection in the requires loop.
+        v.opaque_read_vars_.insert("x");
+        curlee::parser::Expr arg;
+        arg.span = s;
+        arg.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::CallExpr call;
+        call.callee =
+            make_expr_ptr(make_expr(s, curlee::parser::NameExpr{.name = "opaque_req_callee"}));
+        call.args.push_back(std::move(arg));
+        const std::size_t before = v.diags_.size();
+        v.check_call(call);
+        bool saw = false;
+        for (std::size_t i = before; i < v.diags_.size(); ++i)
+        {
+            if (v.diags_[i].message.find("opaque MMIO read") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected check_call requires-loop guard to reject opaque-read requires");
+        }
+        v.opaque_read_vars_.erase("x");
+        v.functions_.erase("opaque_req_callee");
+    }
+
+    {
+        // check_return: ensures mentioning `result` is rejected when the returned value is an
+        // opaque read (review gap #2).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f;
+        f.name = "opaque_ret";
+        f.return_type = curlee::parser::TypeName{.span = s, .name = "U32"};
+        f.ensures.push_back(make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "result"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))}));
+        curlee::verification::FunctionSig sig;
+        sig.decl = &f;
+        sig.result = curlee::types::TypeKind::U32;
+        v.current_function_ = sig;
+
+        // The read() must lower successfully, so register a phys var as its base.
+        v.phys_vars_.insert_or_assign("reg_ret", std::string_view("U32"));
+        curlee::parser::Expr read_base;
+        read_base.span = s;
+        read_base.node = curlee::parser::NameExpr{.name = "reg_ret"};
+        curlee::parser::ReturnStmt r;
+        r.value = make_expr(s, curlee::parser::PhysReadExpr{
+                                  .base = make_expr_ptr(std::move(read_base))});
+        const std::size_t before = v.diags_.size();
+        v.check_return(r, curlee::types::TypeKind::U32);
+        v.phys_vars_.erase("reg_ret");
+        bool saw = false;
+        for (std::size_t i = before; i < v.diags_.size(); ++i)
+        {
+            if (v.diags_[i].message.find("opaque MMIO read") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected check_return to reject ensures on opaque read result");
+        }
+        v.current_function_ = std::nullopt;
+    }
+
+    {
         // check_stmt_node(IfStmt/WhileStmt): cover cond_fact + else branch.
         const curlee::source::Span s{.start = 0, .end = 1};
 

--- a/tests/verification_checker_internal_tests.ipp
+++ b/tests/verification_checker_internal_tests.ipp
@@ -265,6 +265,17 @@ int main()
         {
             fail("expected supported_type(cap foo) to return Unit");
         }
+
+        // supported_type: Phys<T> maps to a distinct Phys kind (opaque sort), not Unit.
+        curlee::parser::TypeName phys_tn;
+        phys_tn.span = curlee::source::Span{.start = 0, .end = 1};
+        phys_tn.name = "Phys";
+        phys_tn.type_arg = std::string_view("U32");
+        const auto phys_t = v.supported_type(phys_tn);
+        if (!phys_t.has_value() || *phys_t != curlee::types::TypeKind::Phys)
+        {
+            fail("expected supported_type(Phys) to return Phys kind");
+        }
     }
 
     {
@@ -1323,6 +1334,127 @@ int main()
         curlee::parser::ReturnStmt rs2;
         rs2.value = std::nullopt;
         v.check_stmt_node(rs2, s, curlee::types::TypeKind::Int);
+    }
+
+    {
+        // LetStmt: Phys<T> binding with a non-literal address lexeme must produce the hard
+        // "physical address must be a constant literal" diagnostic (defense-in-depth, issue
+        // #253). The front-end normally rejects these at parse time, but the verifier must not
+        // trust the AST.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::LetStmt ls_phys;
+        ls_phys.name = "fb_bad";
+        ls_phys.type = curlee::parser::TypeName{.span = s,
+                                                .name = "Phys",
+                                                .type_arg = std::string_view("U32")};
+        ls_phys.value = make_expr(
+            s, curlee::parser::PhysExpr{.element_kind = "U32", .lexeme = "base + 4"});
+        const std::size_t before = v.diags_.size();
+        v.check_stmt_node(ls_phys, s, curlee::types::TypeKind::Int);
+        bool saw_literal = false;
+        for (std::size_t i = before; i < v.diags_.size(); ++i)
+        {
+            if (v.diags_[i].message.find("physical address must be a constant literal") !=
+                std::string::npos)
+            {
+                saw_literal = true;
+            }
+        }
+        if (!saw_literal)
+        {
+            fail("expected non-literal phys address to be rejected by the verifier");
+        }
+
+        // lower_expr(PhysExpr) with a valid literal address should succeed and produce a
+        // Phys-typed ExprValue.
+        curlee::parser::Expr e_phys;
+        e_phys.span = s;
+        e_phys.node = curlee::parser::PhysExpr{.element_kind = "U32", .lexeme = "0xFD00_0000"};
+        auto r_phys = v.lower_expr(e_phys);
+        if (!std::holds_alternative<curlee::verification::ExprValue>(r_phys))
+        {
+            fail("expected lower_expr(PhysExpr) to succeed for literal address");
+        }
+        if (std::get<curlee::verification::ExprValue>(r_phys).kind != curlee::types::TypeKind::Phys)
+        {
+            fail("expected lower_expr(PhysExpr) to produce a Phys-typed value");
+        }
+
+        // lower_expr(PhysExpr) with a non-literal address should error.
+        curlee::parser::Expr e_phys_bad;
+        e_phys_bad.span = s;
+        e_phys_bad.node = curlee::parser::PhysExpr{.element_kind = "U32", .lexeme = "base"};
+        auto r_phys_bad = v.lower_expr(e_phys_bad);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_phys_bad))
+        {
+            fail("expected lower_expr(PhysExpr) to reject non-literal address");
+        }
+
+        // lower_expr(PhysReadExpr) on an unknown base should error.
+        curlee::parser::Expr e_read_base;
+        e_read_base.span = s;
+        e_read_base.node = curlee::parser::NameExpr{.name = "no_such_phys"};
+        curlee::parser::Expr e_read;
+        e_read.span = s;
+        e_read.node = curlee::parser::PhysReadExpr{.base = make_expr_ptr(std::move(e_read_base))};
+        auto r_read = v.lower_expr(e_read);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_read))
+        {
+            fail("expected lower_expr(PhysReadExpr) on unknown base to error");
+        }
+
+        // lower_expr(PhysWriteExpr) on an unknown base should error.
+        curlee::parser::Expr e_write_base;
+        e_write_base.span = s;
+        e_write_base.node = curlee::parser::NameExpr{.name = "no_such_phys"};
+        curlee::parser::Expr e_write_val;
+        e_write_val.span = s;
+        e_write_val.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr e_write;
+        e_write.span = s;
+        e_write.node = curlee::parser::PhysWriteExpr{
+            .base = make_expr_ptr(std::move(e_write_base)),
+            .value = make_expr_ptr(std::move(e_write_val))};
+        auto r_write = v.lower_expr(e_write);
+        if (!std::holds_alternative<curlee::diag::Diagnostic>(r_write))
+        {
+            fail("expected lower_expr(PhysWriteExpr) on unknown base to error");
+        }
+
+        // A valid Phys read()/write() pair should lower without diagnostics once the phys var
+        // is registered.
+        v.phys_vars_.insert_or_assign("fb_good", std::string_view("U32"));
+        curlee::parser::Expr e_good_base;
+        e_good_base.span = s;
+        e_good_base.node = curlee::parser::NameExpr{.name = "fb_good"};
+        curlee::parser::Expr e_read_good;
+        e_read_good.span = s;
+        e_read_good.node = curlee::parser::PhysReadExpr{
+            .base = make_expr_ptr(std::move(e_good_base))};
+        auto r_read_good = v.lower_expr(e_read_good);
+        if (!std::holds_alternative<curlee::verification::ExprValue>(r_read_good))
+        {
+            fail("expected lower_expr(PhysReadExpr) on registered phys var to succeed");
+        }
+
+        curlee::parser::Expr e_w_base;
+        e_w_base.span = s;
+        e_w_base.node = curlee::parser::NameExpr{.name = "fb_good"};
+        curlee::parser::Expr e_w_val;
+        e_w_val.span = s;
+        e_w_val.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr e_write_good;
+        e_write_good.span = s;
+        e_write_good.node = curlee::parser::PhysWriteExpr{
+            .base = make_expr_ptr(std::move(e_w_base)),
+            .value = make_expr_ptr(std::move(e_w_val))};
+        auto r_write_good = v.lower_expr(e_write_good);
+        if (!std::holds_alternative<curlee::verification::ExprValue>(r_write_good))
+        {
+            fail("expected lower_expr(PhysWriteExpr) on registered phys var to succeed");
+        }
+
+        v.phys_vars_.clear();
     }
 
     {

--- a/tests/verification_checker_internal_tests.ipp
+++ b/tests/verification_checker_internal_tests.ipp
@@ -2153,6 +2153,559 @@ int main()
         v.check_stmt_node(ws2, s, curlee::types::TypeKind::Int);
     }
 
+    {
+        // is_phys_address_literal: a char that is not digit/hex/underscore/hex-marker must
+        // return false from inside the loop (branch coverage for lines 213/215).
+        if (curlee::verification::is_phys_address_literal("0x12z4"))
+        {
+            fail("expected is_phys_address_literal(0x12z4) to be false (bad hex char)");
+        }
+        // Decimal digits with underscores.
+        if (!curlee::verification::is_phys_address_literal("12_345"))
+        {
+            fail("expected is_phys_address_literal(12_345) to be true");
+        }
+        // Uppercase hex marker (0X) exercises the 'X' arm.
+        if (!curlee::verification::is_phys_address_literal("0XFD00"))
+        {
+            fail("expected is_phys_address_literal(0XFD00) to be true");
+        }
+        // Non-hex 'g' after a plain digit run: hits the reject branch for a non-digit char.
+        if (curlee::verification::is_phys_address_literal("4096g"))
+        {
+            fail("expected is_phys_address_literal(4096g) to be false");
+        }
+        // A char below '0' (e.g. '-') hits the `c >= '0'` false arm of is_digit.
+        if (curlee::verification::is_phys_address_literal("4-1"))
+        {
+            fail("expected is_phys_address_literal(4-1) to be false (punct char)");
+        }
+        // 'x' at i==1 but lexeme[0] != '0' hits the `lexeme[0] == '0'` false arm.
+        if (curlee::verification::is_phys_address_literal("1x2"))
+        {
+            fail("expected is_phys_address_literal(1x2) to be false (non-zero prefix)");
+        }
+        // A second 'x' later in the lexeme hits the `i == 1` false arm of is_hex_marker.
+        if (curlee::verification::is_phys_address_literal("0x1x2"))
+        {
+            fail("expected is_phys_address_literal(0x1x2) to be false (x at wrong index)");
+        }
+    }
+
+    {
+        // lookup_var: hit the Phys-variable path (returns a Phys ExprValue) and confirm the
+        // int/bool lookups still resolve in the same scope (branch coverage for 388/392/400).
+        v.declare_var("cov_int", curlee::types::TypeKind::Int);
+        v.declare_var("cov_bool", curlee::types::TypeKind::Bool);
+        v.phys_vars_.insert_or_assign("cov_phys", std::string_view("U32"));
+        const auto li = v.lookup_var("cov_int");
+        if (!li.has_value() || li->kind != curlee::types::TypeKind::Int)
+        {
+            fail("expected lookup_var to find int var in combined scope");
+        }
+        const auto lb = v.lookup_var("cov_bool");
+        if (!lb.has_value() || lb->kind != curlee::types::TypeKind::Bool)
+        {
+            fail("expected lookup_var to find bool var in combined scope");
+        }
+        const auto lp = v.lookup_var("cov_phys");
+        if (!lp.has_value() || lp->kind != curlee::types::TypeKind::Phys)
+        {
+            fail("expected lookup_var to find Phys var");
+        }
+        v.phys_vars_.erase("cov_phys");
+        v.lower_ctx_.int_vars.erase("cov_int");
+        v.lower_ctx_.bool_vars.erase("cov_bool");
+    }
+
+    {
+        // pred_mentions_opaque_read / pred_mentions_result: exercise the false-arm of the
+        // recursion so every short-circuit branch is taken at least once.
+        const curlee::source::Span s{.start = 0, .end = 1};
+
+        // Unary with a null rhs.
+        auto p_unary_null = make_pred(
+            s, curlee::parser::PredUnary{.op = curlee::lexer::TokenKind::Bang, .rhs = nullptr});
+        if (v.pred_mentions_opaque_read(p_unary_null))
+        {
+            fail("expected pred_mentions_opaque_read(null unary) to be false");
+        }
+        if (v.pred_mentions_result(p_unary_null))
+        {
+            fail("expected pred_mentions_result(null unary) to be false");
+        }
+
+        // Binary with a null lhs / null rhs.
+        auto p_bin_null_lhs = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = nullptr,
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        if (v.pred_mentions_opaque_read(p_bin_null_lhs))
+        {
+            fail("expected pred_mentions_opaque_read(null-lhs binary) to be false");
+        }
+        if (v.pred_mentions_result(p_bin_null_lhs))
+        {
+            fail("expected pred_mentions_result(null-lhs binary) to be false");
+        }
+
+        auto p_bin_null_rhs = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"})),
+                   .rhs = nullptr});
+        if (v.pred_mentions_opaque_read(p_bin_null_rhs))
+        {
+            fail("expected pred_mentions_opaque_read(null-rhs binary) to be false");
+        }
+        if (v.pred_mentions_result(p_bin_null_rhs))
+        {
+            fail("expected pred_mentions_result(null-rhs binary) to be false");
+        }
+
+        // Group with a null inner.
+        auto p_group_null = make_pred(
+            s, curlee::parser::PredGroup{.inner = nullptr});
+        if (v.pred_mentions_opaque_read(p_group_null))
+        {
+            fail("expected pred_mentions_opaque_read(null group) to be false");
+        }
+        if (v.pred_mentions_result(p_group_null))
+        {
+            fail("expected pred_mentions_result(null group) to be false");
+        }
+    }
+
+    {
+        // expr_is_opaque_read: GroupExpr with an opaque inner that recurses into a true
+        // result (line 611 hit-branch), and BinaryExpr with opaque lhs short-circuiting
+        // before rhs (line 623).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        v.opaque_read_vars_.insert("opg");
+
+        curlee::parser::Expr g_inner;
+        g_inner.span = s;
+        g_inner.node = curlee::parser::NameExpr{.name = "opg"};
+        curlee::parser::Expr group_true;
+        group_true.span = s;
+        group_true.node = curlee::parser::GroupExpr{.inner = make_expr_ptr(std::move(g_inner))};
+        if (!v.expr_is_opaque_read(group_true))
+        {
+            fail("expected expr_is_opaque_read(GroupExpr(opg)) to be true");
+        }
+
+        // BinaryExpr: opaque lhs -> returns true without evaluating rhs (line 621).
+        curlee::parser::Expr b_lhs;
+        b_lhs.span = s;
+        b_lhs.node = curlee::parser::NameExpr{.name = "opg"};
+        curlee::parser::Expr b_rhs;
+        b_rhs.span = s;
+        b_rhs.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr bin_true;
+        bin_true.span = s;
+        bin_true.node = curlee::parser::BinaryExpr{.op = curlee::lexer::TokenKind::Plus,
+                                                   .lhs = make_expr_ptr(std::move(b_lhs)),
+                                                   .rhs = make_expr_ptr(std::move(b_rhs))};
+        if (!v.expr_is_opaque_read(bin_true))
+        {
+            fail("expected expr_is_opaque_read(BinaryExpr opaque lhs) to be true");
+        }
+        v.opaque_read_vars_.erase("opg");
+    }
+
+    {
+        // check_call: opaque argument with an empty args vector must not crash on the
+        // args[0] fallback (line 1014 branch `call.args.empty()`).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function decl;
+        decl.name = "opaque_noargs";
+        decl.return_type = curlee::parser::TypeName{.span = s, .name = "Int"};
+        decl.params.push_back(curlee::parser::Function::Param{
+            .span = s,
+            .name = "x",
+            .type = curlee::parser::TypeName{.span = s, .name = "U32"},
+            .refinement = std::nullopt});
+        curlee::verification::FunctionSig sig;
+        sig.decl = &decl;
+        sig.params = {curlee::types::TypeKind::U32};
+        sig.result = curlee::types::TypeKind::Int;
+        v.functions_.insert_or_assign("opaque_noargs", sig);
+
+        // A PhysReadExpr argument is opaque but no args exist: the guard fires with the
+        // empty-args span fallback (Span{}).
+        curlee::parser::CallExpr call;
+        call.callee =
+            make_expr_ptr(make_expr(s, curlee::parser::NameExpr{.name = "opaque_noargs"}));
+        // arg is opaque but the call has zero args; expr_is_opaque_read is only true if the
+        // arg itself is a read — use a direct read as a synthetic arg with no args stored.
+        v.check_call(call);
+        // With no args, arg_is_opaque stays false, so no diagnostic is expected; this just
+        // exercises the arg-count guard path (line 1022) with the empty-args span fallback.
+        v.functions_.erase("opaque_noargs");
+
+        // Also exercise the arg_count mismatch early-return with an opaque argument present,
+        // which is the path that leads to the empty-args span fallback being compiled.
+        curlee::parser::CallExpr call2;
+        call2.callee =
+            make_expr_ptr(make_expr(s, curlee::parser::NameExpr{.name = "opaque_noargs"}));
+        curlee::parser::Expr read_arg;
+        read_arg.span = s;
+        read_arg.node = curlee::parser::PhysReadExpr{.base = nullptr};
+        call2.args.push_back(std::move(read_arg));
+        const std::size_t before2 = v.diags_.size();
+        v.check_call(call2);
+        (void)before2;
+        v.functions_.erase("opaque_noargs");
+    }
+
+    {
+        // check_expr_for_calls: PhysReadExpr/PhysWriteExpr with null base/value children
+        // must not dereference null (line 1148/1155/1159).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Expr read_null;
+        read_null.span = s;
+        read_null.node = curlee::parser::PhysReadExpr{.base = nullptr};
+        v.check_expr_for_calls(read_null);
+
+        curlee::parser::Expr write_null;
+        write_null.span = s;
+        write_null.node = curlee::parser::PhysWriteExpr{.base = nullptr, .value = nullptr};
+        v.check_expr_for_calls(write_null);
+
+        // And with non-null children (hit the recursion).
+        curlee::parser::Expr w_base;
+        w_base.span = s;
+        w_base.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr w_val;
+        w_val.span = s;
+        w_val.node = curlee::parser::IntExpr{.lexeme = "2"};
+        curlee::parser::Expr write_full;
+        write_full.span = s;
+        write_full.node = curlee::parser::PhysWriteExpr{
+            .base = make_expr_ptr(std::move(w_base)),
+            .value = make_expr_ptr(std::move(w_val))};
+        v.check_expr_for_calls(write_full);
+    }
+
+    {
+        // check_return: opaque-ensures where the ensures mentions `result` on the rhs, and
+        // the return value kind mismatch branch is avoided via opaque_unsigned_return.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f;
+        f.name = "opaque_ret_rhs";
+        f.return_type = curlee::parser::TypeName{.span = s, .name = "U32"};
+        f.ensures.push_back(make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Less,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"})),
+                   .rhs = make_pred_ptr(
+                       make_pred(s, curlee::parser::PredName{.name = "result"}))}));
+        curlee::verification::FunctionSig sig;
+        sig.decl = &f;
+        sig.result = curlee::types::TypeKind::U32;
+        v.current_function_ = sig;
+
+        v.phys_vars_.insert_or_assign("reg_rhs", std::string_view("U32"));
+        curlee::parser::Expr read_base;
+        read_base.span = s;
+        read_base.node = curlee::parser::NameExpr{.name = "reg_rhs"};
+        curlee::parser::ReturnStmt r;
+        r.value = make_expr(s, curlee::parser::PhysReadExpr{
+                                   .base = make_expr_ptr(std::move(read_base))});
+        const std::size_t before = v.diags_.size();
+        v.check_return(r, curlee::types::TypeKind::U32);
+        v.phys_vars_.erase("reg_rhs");
+        bool saw = false;
+        for (std::size_t i = before; i < v.diags_.size(); ++i)
+        {
+            if (v.diags_[i].message.find("opaque MMIO read") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected check_return to reject ensures with result on rhs of opaque read");
+        }
+        v.current_function_ = std::nullopt;
+    }
+
+    {
+        // check_stmt_node LetStmt: Phys binding with a missing type_arg (line 1272 false arm)
+        // and with a value that is not a direct PhysExpr (line 1278 false arm).
+        const curlee::source::Span s{.start = 0, .end = 1};
+
+        // Phys type without type_arg: the branch `if (s.type.type_arg.has_value())` is false.
+        curlee::parser::LetStmt ls_no_arg;
+        ls_no_arg.name = "phys_no_arg";
+        ls_no_arg.type = curlee::parser::TypeName{.span = s, .name = "Phys"};
+        ls_no_arg.value = make_expr(
+            s, curlee::parser::PhysExpr{.element_kind = "U32", .lexeme = "0x1000"});
+        v.check_stmt_node(ls_no_arg, s, curlee::types::TypeKind::Int);
+
+        // Phys binding whose value is a NameExpr (not a direct PhysExpr): the `std::get_if`
+        // at line 1278 is false, so no address re-validation is attempted.
+        curlee::parser::LetStmt ls_name_val;
+        ls_name_val.name = "phys_name_val";
+        ls_name_val.type = curlee::parser::TypeName{.span = s,
+                                                    .name = "Phys",
+                                                    .type_arg = std::string_view("U32")};
+        ls_name_val.value = make_expr(s, curlee::parser::NameExpr{.name = "other_phys"});
+        v.check_stmt_node(ls_name_val, s, curlee::types::TypeKind::Int);
+    }
+
+    {
+        // check_stmt_node LetStmt: unsigned binding whose value is NOT a read and has no
+        // refinement — exercises the transitive expr_is_opaque_read false-arm (line 1323).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::LetStmt ls_u32_plain;
+        ls_u32_plain.name = "u32_plain";
+        ls_u32_plain.type = curlee::parser::TypeName{.span = s,
+                                                     .name = "U32",
+                                                     .type_arg = std::string_view("U32")};
+        ls_u32_plain.value = make_expr(s, curlee::parser::IntExpr{.lexeme = "5"});
+        v.check_stmt_node(ls_u32_plain, s, curlee::types::TypeKind::Int);
+
+        // Unsigned binding whose refinement does NOT mention an opaque read: the
+        // `pred_mentions_opaque_read` false-arm at line 1330 — no diagnostic expected.
+        curlee::parser::LetStmt ls_u32_refine_plain;
+        ls_u32_refine_plain.name = "u32_refine_plain";
+        ls_u32_refine_plain.type = curlee::parser::TypeName{.span = s,
+                                                            .name = "U32",
+                                                            .type_arg = std::string_view("U32")};
+        ls_u32_refine_plain.refinement = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(
+                       make_pred(s, curlee::parser::PredName{.name = "plain"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        ls_u32_refine_plain.value = make_expr(s, curlee::parser::IntExpr{.lexeme = "5"});
+        const std::size_t before = v.diags_.size();
+        v.check_stmt_node(ls_u32_refine_plain, s, curlee::types::TypeKind::Int);
+        if (v.diags_.size() != before)
+        {
+            fail("expected unsigned let refinement on a plain value to emit no diagnostic");
+        }
+    }
+
+    {
+        // check_stmt_node LetStmt: an unsigned binding with a refinement that mentions an
+        // opaque name must emit the hard diagnostic (line 1329 predicate path), and a binding
+        // whose value is a NameExpr (not a direct read) exercises the transitive-provenance
+        // short-circuit in the same guard.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        v.opaque_read_vars_.insert("opaque_let");
+        curlee::parser::LetStmt ls_refine;
+        ls_refine.name = "u32_refined";
+        ls_refine.type = curlee::parser::TypeName{.span = s,
+                                                  .name = "U32",
+                                                  .type_arg = std::string_view("U32")};
+        ls_refine.refinement = make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(
+                       make_pred(s, curlee::parser::PredName{.name = "opaque_let"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))});
+        ls_refine.value = make_expr(s, curlee::parser::NameExpr{.name = "opaque_let"});
+        const std::size_t before = v.diags_.size();
+        v.check_stmt_node(ls_refine, s, curlee::types::TypeKind::Int);
+        bool saw = false;
+        for (std::size_t i = before; i < v.diags_.size(); ++i)
+        {
+            if (v.diags_[i].message.find("opaque MMIO read") != std::string::npos)
+            {
+                saw = true;
+            }
+        }
+        if (!saw)
+        {
+            fail("expected unsigned let refinement on opaque value to be rejected");
+        }
+        v.opaque_read_vars_.erase("opaque_let");
+    }
+
+    {
+        // pred_mentions_opaque_read / pred_mentions_result / expr_is_opaque_read: cover the
+        // remaining recursion arms that produce a false result when the child is non-null but
+        // does not match (lines 545/563/611/623).
+        const curlee::source::Span s{.start = 0, .end = 1};
+
+        // Unary with a non-null non-matching child (pred_mentions_result line 545).
+        auto p_unary_nomatch = make_pred(
+            s, curlee::parser::PredUnary{
+                   .op = curlee::lexer::TokenKind::Bang,
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "y"}))});
+        if (v.pred_mentions_result(p_unary_nomatch))
+        {
+            fail("expected pred_mentions_result(!y) to be false");
+        }
+
+        // Group with a non-null non-matching child (pred_mentions_result line 563).
+        auto p_group_nomatch = make_pred(
+            s, curlee::parser::PredGroup{
+                   .inner = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "y"}))});
+        if (v.pred_mentions_result(p_group_nomatch))
+        {
+            fail("expected pred_mentions_result((y)) to be false");
+        }
+
+        // GroupExpr with a non-null non-opaque child (expr_is_opaque_read line 611).
+        curlee::parser::Expr g_plain_inner;
+        g_plain_inner.span = s;
+        g_plain_inner.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr g_plain;
+        g_plain.span = s;
+        g_plain.node = curlee::parser::GroupExpr{.inner = make_expr_ptr(std::move(g_plain_inner))};
+        if (v.expr_is_opaque_read(g_plain))
+        {
+            fail("expected expr_is_opaque_read(GroupExpr plain) to be false");
+        }
+
+        // BinaryExpr: plain lhs short-circuits the rhs check (expr_is_opaque_read line 623).
+        curlee::parser::Expr b2_lhs;
+        b2_lhs.span = s;
+        b2_lhs.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr b2_rhs;
+        b2_rhs.span = s;
+        b2_rhs.node = curlee::parser::IntExpr{.lexeme = "2"};
+        curlee::parser::Expr b2;
+        b2.span = s;
+        b2.node = curlee::parser::BinaryExpr{.op = curlee::lexer::TokenKind::Plus,
+                                             .lhs = make_expr_ptr(std::move(b2_lhs)),
+                                             .rhs = make_expr_ptr(std::move(b2_rhs))};
+        if (v.expr_is_opaque_read(b2))
+        {
+            fail("expected expr_is_opaque_read(BinaryExpr plain lhs) to be false");
+        }
+
+        // BinaryExpr with a null rhs: `node.rhs != nullptr` short-circuits to false without
+        // recursing into the rhs (line 623 false-arm).
+        curlee::parser::Expr b3_lhs;
+        b3_lhs.span = s;
+        b3_lhs.node = curlee::parser::IntExpr{.lexeme = "1"};
+        curlee::parser::Expr b3;
+        b3.span = s;
+        b3.node = curlee::parser::BinaryExpr{.op = curlee::lexer::TokenKind::Plus,
+                                             .lhs = make_expr_ptr(std::move(b3_lhs)),
+                                             .rhs = nullptr};
+        if (v.expr_is_opaque_read(b3))
+        {
+            fail("expected expr_is_opaque_read(BinaryExpr null rhs) to be false");
+        }
+    }
+
+    {
+        // check_return: opaque unsigned return whose ensures does NOT mention `result` (so
+        // pred_mentions_result is false at line 1216) — no diagnostic should be emitted, and
+        // the opaque-unsigned-return acceptance at 1201/1202 is exercised.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f;
+        f.name = "opaque_ret_nores";
+        f.return_type = curlee::parser::TypeName{.span = s, .name = "U32"};
+        // ensures mentions only an unrelated name, not `result`.
+        f.ensures.push_back(make_pred(
+            s, curlee::parser::PredBinary{
+                   .op = curlee::lexer::TokenKind::Greater,
+                   .lhs = make_pred_ptr(make_pred(s, curlee::parser::PredName{.name = "zzz"})),
+                   .rhs = make_pred_ptr(make_pred(s, curlee::parser::PredInt{.lexeme = "0"}))}));
+        curlee::verification::FunctionSig sig;
+        sig.decl = &f;
+        sig.result = curlee::types::TypeKind::U32;
+        v.current_function_ = sig;
+
+        v.phys_vars_.insert_or_assign("reg_nores", std::string_view("U32"));
+        curlee::parser::Expr read_base;
+        read_base.span = s;
+        read_base.node = curlee::parser::NameExpr{.name = "reg_nores"};
+        curlee::parser::ReturnStmt r;
+        r.value = make_expr(s, curlee::parser::PhysReadExpr{
+                                   .base = make_expr_ptr(std::move(read_base))});
+        const std::size_t before = v.diags_.size();
+        v.check_return(r, curlee::types::TypeKind::U32);
+        v.phys_vars_.erase("reg_nores");
+        if (v.diags_.size() != before)
+        {
+            fail("expected check_return with ensures not mentioning result to emit no diag");
+        }
+        v.current_function_ = std::nullopt;
+    }
+
+    {
+        // check_return: an unsigned-returning function returning a plain Int literal must
+        // take the return-type-mismatch early-return (opaque_unsigned_return is false because
+        // the value is not opaque) — exercises the false-arms of lines 1202/1203.
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f2;
+        f2.name = "plain_u32_ret";
+        f2.return_type = curlee::parser::TypeName{.span = s, .name = "U32"};
+        curlee::verification::FunctionSig sig2;
+        sig2.decl = &f2;
+        sig2.result = curlee::types::TypeKind::U32;
+        v.current_function_ = sig2;
+
+        curlee::parser::ReturnStmt r2;
+        r2.value = make_expr(s, curlee::parser::IntExpr{.lexeme = "5"});
+        const std::size_t before2 = v.diags_.size();
+        v.check_return(r2, curlee::types::TypeKind::U32);
+        if (v.diags_.size() != before2)
+        {
+            fail("expected check_return with plain Int for U32 return to emit no diag");
+        }
+        v.current_function_ = std::nullopt;
+    }
+
+    {
+        // check_return: a U32-returning function returning a Bool literal — value.kind is
+        // neither Int nor the expected U32, so opaque_unsigned_return short-circuits at the
+        // `value.kind == TypeKind::Int` conjunct (line 1202 false-arm) and the function
+        // returns via the mismatch guard (no diagnostics).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f3;
+        f3.name = "bool_to_u32_ret";
+        f3.return_type = curlee::parser::TypeName{.span = s, .name = "U32"};
+        curlee::verification::FunctionSig sig3;
+        sig3.decl = &f3;
+        sig3.result = curlee::types::TypeKind::U32;
+        v.current_function_ = sig3;
+
+        curlee::parser::ReturnStmt r3;
+        r3.value = make_expr(s, curlee::parser::BoolExpr{.value = true});
+        const std::size_t before3 = v.diags_.size();
+        v.check_return(r3, curlee::types::TypeKind::U32);
+        if (v.diags_.size() != before3)
+        {
+            fail("expected check_return with Bool for U32 return to emit no diag");
+        }
+        v.current_function_ = std::nullopt;
+    }
+
+    {
+        // check_function: a Phys parameter WITHOUT a type_arg exercises the false-arm of the
+        // `param.type.type_arg.has_value()` guard (line 1495).
+        const curlee::source::Span s{.start = 0, .end = 1};
+        curlee::parser::Function f;
+        f.name = "phys_param_no_arg";
+        f.return_type = curlee::parser::TypeName{.span = s, .name = "Int"};
+        f.params.push_back(curlee::parser::Function::Param{
+            .span = s,
+            .name = "fb",
+            .type = curlee::parser::TypeName{.span = s, .name = "Phys"},
+            .refinement = std::nullopt});
+        curlee::verification::FunctionSig sig;
+        sig.decl = &f;
+        sig.params = {curlee::types::TypeKind::Phys};
+        sig.result = curlee::types::TypeKind::Int;
+        v.functions_.insert_or_assign("phys_param_no_arg", sig);
+        const std::size_t before = v.diags_.size();
+        v.check_function(f);
+        if (v.diags_.size() != before)
+        {
+            fail("expected check_function with no-arg Phys param to complete without diagnostics");
+        }
+        v.functions_.erase("phys_param_no_arg");
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/verification_checker_tests.cpp
+++ b/tests/verification_checker_tests.cpp
@@ -866,6 +866,33 @@ int main()
         }
     }
 
+    {
+        // Phys<T> read values are opaque: a refinement on a read() result cannot be proven and
+        // must fail with the opaque-value note (issue #253, documented restriction).
+        const std::string source = "fn main(pm: cap phys.mem) -> Int {\n"
+                                   "  unsafe {\n"
+                                   "    let reg: Phys<U32> = phys<U32>(0xFE00_0000);\n"
+                                   "    let v: U32 where v > 0 = reg.read();\n"
+                                   "  }\n"
+                                   "  return 0;\n"
+                                   "}\n";
+
+        const auto verified = verify_program(source, "Phys opaque read contract test");
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(verified))
+        {
+            fail("expected verification to fail for opaque MMIO read contract");
+        }
+        const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(verified);
+        if (!has_message_substr(diags, "cannot prove refinement on opaque MMIO read value"))
+        {
+            fail("expected opaque-read refinement diagnostic");
+        }
+        if (!any_note_has_substr(diags, "MMIO read is opaque; cannot prove this contract"))
+        {
+            fail("expected opaque-read note attached to diagnostic");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/verification_checker_tests.cpp
+++ b/tests/verification_checker_tests.cpp
@@ -893,6 +893,98 @@ int main()
         }
     }
 
+    {
+        // Opaque provenance is transitive: a refinement on an alias of a read() result must
+        // also fail (review gap #3).
+        const std::string source = "fn main(pm: cap phys.mem) -> Int {\n"
+                                   "  unsafe {\n"
+                                   "    let reg: Phys<U32> = phys<U32>(0xFE00_0000);\n"
+                                   "    let v: U32 = reg.read();\n"
+                                   "    let w: U32 = v;\n"
+                                   "    let x: U32 where x > 0 = w;\n"
+                                   "  }\n"
+                                   "  return 0;\n"
+                                   "}\n";
+
+        const auto verified = verify_program(source, "Phys opaque read transitive alias test");
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(verified))
+        {
+            fail("expected verification to fail for transitive opaque alias refinement");
+        }
+        const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(verified);
+        if (!has_message_substr(diags, "cannot prove refinement on opaque MMIO read value"))
+        {
+            fail("expected opaque-read refinement diagnostic for transitive alias");
+        }
+        if (!any_note_has_substr(diags, "MMIO read is opaque; cannot prove this contract"))
+        {
+            fail("expected opaque-read note for transitive alias");
+        }
+    }
+
+    {
+        // An opaque read value must never silently satisfy a requires-guarded call with an
+        // unsigned parameter (review gap #1).
+        const std::string source = "fn consume(x: U32) -> Int [\n"
+                                   "  requires x > 0;\n"
+                                   "] {\n"
+                                   "  return 0;\n"
+                                   "}\n"
+                                   "fn main(pm: cap phys.mem) -> Int {\n"
+                                   "  unsafe {\n"
+                                   "    let reg: Phys<U32> = phys<U32>(0xFE00_0000);\n"
+                                   "    let v: U32 = reg.read();\n"
+                                   "    return consume(v);\n"
+                                   "  }\n"
+                                   "}\n";
+
+        const auto verified = verify_program(source, "Phys opaque read requires-call test");
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(verified))
+        {
+            fail("expected verification to fail for requires-guarded call on opaque read");
+        }
+        const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(verified);
+        if (!has_message_substr(diags, "opaque MMIO read"))
+        {
+            fail("expected opaque-read diagnostic for requires-guarded call");
+        }
+        if (!any_note_has_substr(diags, "MMIO read is opaque; cannot prove this contract"))
+        {
+            fail("expected opaque-read note for requires-guarded call");
+        }
+    }
+
+    {
+        // A function returning an opaque read value cannot satisfy `ensures result > 0`
+        // (review gap #2).
+        const std::string source = "fn read_reg(pm: cap phys.mem) -> U32 [\n"
+                                   "  ensures result > 0;\n"
+                                   "] {\n"
+                                   "  unsafe {\n"
+                                   "    let reg: Phys<U32> = phys<U32>(0xFE00_0000);\n"
+                                   "    return reg.read();\n"
+                                   "  }\n"
+                                   "}\n"
+                                   "fn main() -> Int {\n"
+                                   "  return 0;\n"
+                                   "}\n";
+
+        const auto verified = verify_program(source, "Phys opaque read ensures-result test");
+        if (!std::holds_alternative<std::vector<curlee::diag::Diagnostic>>(verified))
+        {
+            fail("expected verification to fail for ensures on opaque read result");
+        }
+        const auto& diags = std::get<std::vector<curlee::diag::Diagnostic>>(verified);
+        if (!has_message_substr(diags, "cannot prove ensures on opaque MMIO read result"))
+        {
+            fail("expected opaque-read ensures diagnostic");
+        }
+        if (!any_note_has_substr(diags, "MMIO read is opaque; cannot prove this contract"))
+        {
+            fail("expected opaque-read note for ensures");
+        }
+    }
+
     std::cout << "OK\n";
     return 0;
 }


### PR DESCRIPTION
Closes #253

## Summary

Defines the **verification semantics** for physical memory access (`Phys<T>`), completing the front-end work from issue #252.

### Design

- `Phys<T>` lowers to an **opaque Z3 sort** (one fresh sort per element kind: `PhysU8`/`PhysU16`/`PhysU32`/`PhysU64`).
- `phys<U>(addr_literal)` lowers to a constant of that sort.
- `read()` lowers to the **uninterpreted function** `phys_read : Phys<T> -> T`.
- `write(v)` lowers to the uninterpreted function `phys_write : Phys<T> x T -> Unit`.
- **No axioms are added**: the solver cannot derive `read()` values, cannot compare two reads, and cannot reason about written values — sound-by-omission.
- **Second-line enforcement**: a hand-crafted non-literal address reaching the verifier produces the hard `"physical address must be a constant literal"` diagnostic (defense in depth; the front-end already rejects these at parse time).
- **Opaque-value contract rule**: a refinement/contract mentioning a `read()` result fails with the note `MMIO read is opaque; cannot prove this contract` — a documented restriction, not a silent pass.

### Changes

- `src/verification/checker.cpp`: `Phys` as a distinct `TypeKind` (not `Unit`), phys var tracking (name → element kind), opaque sort/function lowering, address-literal re-validation, opaque-read note on refinements/requires/ensures.
- `tests/fixtures/check_phys_framebuffer.curlee` (positive — passes with zero obligations) + golden.
- `tests/fixtures/check_phys_read_contract.curlee` (negative — opaque-value note) + golden.
- Unit tests in `tests/verification_checker_tests.cpp` and `tests/verification_checker_internal_tests.ipp` covering lowering, address re-validation, and the opaque-contract note.

### Test results

Full suite: 62/62 pass locally (verified with system libz3 + clang-format installed).

### Out of scope (per issue)

Bounds proofs on MMIO regions, read-after-write tracking, volatile semantics, and VM/bytecode execution of Phys ops (freestanding-only, later issues). Int/bool contract fragment unchanged.