### PR TITLE
feat(build): bundle 32-bit libgcc32 helpers into the i386 freestanding link (issue #288)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 build/
 
+# Agent/harness scratch (never committed).
+.headlesscode/
+.env
+.harness.*
+harness.log
+ORCHESTRATOR_TASK.md
+
 # Z3 build artifact (written to the invoking directory by the vendored Z3 build).
 .z3-trace
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1164,7 +1164,7 @@ if(CURLEE_ENABLE_FREESTANDING_SMOKE)
 
   # Each smoke test writes its emitted .c into its own subdirectory to avoid
   # races when ctest runs tests in parallel.
-  foreach(_fixture arith control_flow while_loop struct_fixture enum_match match_stmt phys_mem phys_param empty_union_enum forward_ref unit_empty match_unit_arms mixed_payload_enum phys_param_forward while_loop_unit multi_function extern_fn io_port unsigned_widen u64_widen array phys_read_runtime phys_write_runtime addr_of shadow_arrays)
+  foreach(_fixture arith control_flow while_loop struct_fixture enum_match match_stmt phys_mem phys_param empty_union_enum forward_ref unit_empty match_unit_arms mixed_payload_enum phys_param_forward while_loop_unit multi_function extern_fn io_port unsigned_widen u64_widen array phys_read_runtime phys_write_runtime addr_of shadow_arrays kernel_libgcc32 kernel_libgcc32_extern kernel_libgcc32_u64_only kernel_nolibgcc32)
     set(_fixture_workdir "${CMAKE_BINARY_DIR}/codegen_smoke_${_fixture}")
     file(MAKE_DIRECTORY "${_fixture_workdir}")
     add_test(
@@ -1195,6 +1195,26 @@ if(CURLEE_ENABLE_FREESTANDING_SMOKE)
       -P ${CMAKE_SOURCE_DIR}/cmake/linker_boot_smoke.cmake
   )
   set_tests_properties(curlee_linker_boot_smoke PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+
+  # i386 link smoke (issue #288): `curlee build --link --arch i386` auto-links
+  # the bundled libgcc32 helpers for 64-bit-arithmetic kernels (no downstream
+  # helper file) and the default x86_64 PVH link carries NONE of them. Skips
+  # visibly when the C toolchain lacks -m32 support. Requires readelf/nm/ld.
+  set(_i386_workdir "${CMAKE_BINARY_DIR}/i386_link_smoke")
+  file(MAKE_DIRECTORY "${_i386_workdir}")
+  add_test(
+    NAME curlee_i386_link_smoke
+    COMMAND ${CMAKE_COMMAND}
+      -Dcurlee_binary=$<TARGET_FILE:curlee>
+      -Dcurlee_fixture=${CMAKE_SOURCE_DIR}/tests/codegen/kernel_libgcc32.curlee
+      -Dcurlee_fixture_u64_only=${CMAKE_SOURCE_DIR}/tests/codegen/kernel_libgcc32_u64_only.curlee
+      -Dcurlee_fixture_no64=${CMAKE_SOURCE_DIR}/tests/codegen/kernel_nolibgcc32.curlee
+      -Dcurlee_outdir=${_i386_workdir}
+      -P ${CMAKE_SOURCE_DIR}/cmake/i386_link_smoke.cmake
+  )
+  set_tests_properties(curlee_i386_link_smoke PROPERTIES
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
 
@@ -1246,6 +1266,22 @@ target_include_directories(curlee_runtime_mem_tests PRIVATE
 target_link_libraries(curlee_runtime_mem_tests PRIVATE curlee_rt)
 target_compile_options(curlee_runtime_mem_tests PRIVATE -fno-builtin)
 add_test(NAME curlee_runtime_mem_tests COMMAND curlee_runtime_mem_tests)
+
+# Host-visible unit tests for the bundled 32-bit libgcc-ABI helpers
+# (runtime/libgcc32_helpers.c, issue #288). The helpers are compiled into the
+# x86-64 test binary and cross-checked against native 64-bit arithmetic over
+# the edge-case vectors the issue's verification plan lists (divide by zero,
+# negative operands, shift counts >= 32/64, the two-divl single-word-divisor
+# path). -fno-builtin keeps the compiler from constant-folding the calls.
+add_executable(curlee_libgcc32_helpers_tests
+  tests/libgcc32_helpers_tests.cpp
+  runtime/libgcc32_helpers.c
+)
+target_include_directories(curlee_libgcc32_helpers_tests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/runtime
+)
+target_compile_options(curlee_libgcc32_helpers_tests PRIVATE -fno-builtin)
+add_test(NAME curlee_libgcc32_helpers_tests COMMAND curlee_libgcc32_helpers_tests)
 
 # Freestanding compile-smoke: rt.c compiles with
 # `gcc -ffreestanding -fno-builtin -nostdlib -c -Wall -Wextra -Wpedantic

--- a/README.md
+++ b/README.md
@@ -158,14 +158,21 @@ At a high level:
 ### Freestanding targets (kernel)
 
 Curlee can also emit a verified program as **freestanding C** and, with `--link`, link it into a
-bootable **x86-64 multiboot2 kernel ELF**:
+bootable kernel ELF:
 
 - `curlee build <entry.curlee>` — verify, then emit freestanding C (default `out.c`).
 - `curlee build --link -o kernel.elf <entry.curlee>` — emit C, compile it with
-  `gcc -ffreestanding -fno-builtin -nostdlib -c`, assemble `runtime/crt0.S`, and link with
+  `gcc -ffreestanding -fno-builtin -nostdlib -c`, assemble the boot stub, and link with
   `runtime/linker.ld` into `kernel.elf`.
+- `curlee build --link --arch i386 -o kernel32.elf <entry.curlee>` — same pipeline as a **fully
+  32-bit ELF** (`-m32`, `ld -m elf_i386`, `runtime/crt0_i386.S`). When the emitted C uses
+  64-bit integer arithmetic (`Int`/`U64`), the bundled 32-bit libgcc-ABI helpers
+  (`runtime/libgcc32_helpers.c`) are compiled and linked **automatically** — downstream
+  projects never provide their own `libgcc32.c` (issue #288). The default `--arch x86_64`
+  (multiboot2/PVH) target has native `int64_t` arithmetic and never links the helpers.
 - The **verification gate applies**: no proof, no build (nothing is emitted on failure).
-- The freestanding target is **Linux/x86-64 only** and has **no hosted builtins** (no `print`,
+- The freestanding target is **Linux/x86-64 host only** (x86-64 or i386 kernel ELF) and has
+  **no hosted builtins** (no `print`,
   no `String`, no `Vec`). Physical memory access uses `Phys<T>` + `read()`/`write()` under
   `unsafe` and requires the `phys.mem` capability. The **runtime-address reads**
   `phys_read_u8`/`phys_read_u16`/`phys_read_u32`/`phys_read_u64` (issue #279) and **writes**

--- a/cmake/i386_link_smoke.cmake
+++ b/cmake/i386_link_smoke.cmake
@@ -24,12 +24,14 @@
 #     .got.plt out of .text).
 #
 # Optional fixtures pin the auto-link gate in cli_impl.ipp from both sides:
-#   - curlee_fixture_u64_only: emitted C has uint64_t but NO int64_t (the
-#     language maps Int->int64_t and U64->uint64_t, so a U64-only program is
-#     the one case where the `find("int64_t")` check misses). The gate still
-#     links the helpers via the uint64_t clause. 32-bit-only: the 64-bit PVH
-#     target never links the helpers, so the extern __udivdi3 call would be
-#     an undefined symbol there.
+#   - curlee_fixture_u64_only: a program using ONLY U64 (no Int). Its emitted
+#     C contains uint64_t — and since the token "uint64_t" embeds the
+#     substring "int64_t", the gate's `find("int64_t")` check fires and the
+#     helpers are linked. (A separate find("uint64_t") clause in the gate is
+#     dead code by construction; see the fixture header.) This proves a
+#     U64-only kernel links AND boots with the bundled helpers. 32-bit-only:
+#     the 64-bit PVH target never links the helpers, so the extern __udivdi3
+#     call would be an undefined symbol there.
 #   - curlee_fixture_no64: emitted C has neither int64_t nor uint64_t (a
 #     kernel whose only extern takes/returns nothing). On i386 the gate must
 #     NOT link the helpers, and a stale curlee_libgcc32.o from an earlier
@@ -49,8 +51,9 @@ if(NOT DEFINED curlee_outdir)
   message(FATAL_ERROR "curlee_outdir not set")
 endif()
 
-# Optional gate-pinning fixtures (see header comment): U64-only (uint64_t but
-# no int64_t) and no-64-bit-types-at-all.
+# Optional gate-pinning fixtures (see header comment): U64-only (emitted C
+# with uint64_t, which embeds the int64_t substring) and
+# no-64-bit-types-at-all.
 if(NOT DEFINED curlee_fixture_u64_only)
   set(curlee_fixture_u64_only "")
 endif()
@@ -205,10 +208,10 @@ curlee_link_fixture("" "${_elf64}" "${curlee_fixture}")
 curlee_check_elf_class("${_elf64}" "ELF64" "Advanced Micro Devices X86-64")
 curlee_check_helpers("${_elf64}" FALSE)
 
-# 3. U64-only fixture (uint64_t but no int64_t in the emitted C), --arch i386:
-#    the auto-link gate must still link the helpers via the uint64_t clause.
-#    32-bit-only: x86_64 never links the helpers, so the extern __udivdi3
-#    call would be an undefined symbol there (not asserted).
+# 3. U64-only fixture (emitted C has uint64_t, which embeds the int64_t
+#    substring the gate checks), --arch i386: the auto-link gate must still
+#    link the helpers. 32-bit-only: x86_64 never links the helpers, so the
+#    extern __udivdi3 call would be an undefined symbol there (not asserted).
 if(NOT curlee_fixture_u64_only STREQUAL "")
   set(_elf32_u64 "${curlee_outdir}/kernel32_u64only.elf")
   curlee_link_fixture("i386" "${_elf32_u64}" "${curlee_fixture_u64_only}")

--- a/cmake/i386_link_smoke.cmake
+++ b/cmake/i386_link_smoke.cmake
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: MIT
+# i386 link-boot smoke test for `curlee build --link --arch i386` (issue #288).
+#
+# Usage:
+#   cmake -Dcurlee_binary=<path to curlee>
+#         -Dcurlee_fixture=<path to .curlee kernel fixture using 64-bit Int>
+#         -Dcurlee_outdir=<scratch dir for the output ELFs>
+#         [-Dcurlee_fixture_u64_only=<path to U64-only fixture (no Int)>]
+#         [-Dcurlee_fixture_no64=<path to fixture with no 64-bit types>]
+#         -P cmake/i386_link_smoke.cmake
+#
+# Proves the issue #288 acceptance criteria without qemu:
+#   - a 32-bit freestanding kernel using 64-bit arithmetic links via
+#     `curlee build --link --arch i386` with NO downstream-supplied helper file:
+#     the bundled runtime/libgcc32_helpers.c is compiled and linked
+#     automatically, so every libgcc-ABI symbol (__muldi3/__udivdi3/...) is
+#     present in the resulting ELF;
+#   - the output is a fully 32-bit ELF (ELFCLASS32, Intel 80386) with the
+#     boot-critical sections and _start entry;
+#   - the 64-bit PVH target (default --arch) is UNAFFECTED: the same fixture
+#     linked without --arch contains NONE of the helper symbols;
+#   - the 32-bit image has no RWX LOAD segment (the linker.ld .bss page-align
+#     keeps .bss/.stack in a separate RW segment, and -fno-pie -fno-pic keeps
+#     .got.plt out of .text).
+#
+# Optional fixtures pin the auto-link gate in cli_impl.ipp from both sides:
+#   - curlee_fixture_u64_only: emitted C has uint64_t but NO int64_t (the
+#     language maps Int->int64_t and U64->uint64_t, so a U64-only program is
+#     the one case where the `find("int64_t")` check misses). The gate still
+#     links the helpers via the uint64_t clause. 32-bit-only: the 64-bit PVH
+#     target never links the helpers, so the extern __udivdi3 call would be
+#     an undefined symbol there.
+#   - curlee_fixture_no64: emitted C has neither int64_t nor uint64_t (a
+#     kernel whose only extern takes/returns nothing). On i386 the gate must
+#     NOT link the helpers, and a stale curlee_libgcc32.o from an earlier
+#     i386 build into the same output directory is dropped; x86_64 is
+#     unaffected. This is the "no 64-bit types" side of the gate.
+#
+# The qemu boot (32-bit + 64-bit serial-identical smoke) is covered by the
+# freestanding CI job; this is the CI-friendly link-level subset.
+
+if(NOT DEFINED curlee_binary)
+  message(FATAL_ERROR "curlee_binary not set")
+endif()
+if(NOT DEFINED curlee_fixture)
+  message(FATAL_ERROR "curlee_fixture not set")
+endif()
+if(NOT DEFINED curlee_outdir)
+  message(FATAL_ERROR "curlee_outdir not set")
+endif()
+
+# Optional gate-pinning fixtures (see header comment): U64-only (uint64_t but
+# no int64_t) and no-64-bit-types-at-all.
+if(NOT DEFINED curlee_fixture_u64_only)
+  set(curlee_fixture_u64_only "")
+endif()
+if(NOT DEFINED curlee_fixture_no64)
+  set(curlee_fixture_no64 "")
+endif()
+
+find_program(curlee_readelf NAMES readelf)
+find_program(curlee_nm NAMES nm)
+find_program(curlee_ld NAMES ld)
+if(NOT curlee_readelf)
+  message(FATAL_ERROR "readelf not found; cannot run i386 link smoke")
+endif()
+if(NOT curlee_nm)
+  message(FATAL_ERROR "nm not found; cannot run i386 link smoke")
+endif()
+
+# The i386 link requires a C toolchain with 32-bit (-m32 / ld -m elf_i386)
+# support. Some runners install only the x86-64 libc/gcc runtime, so probe
+# with a trivial freestanding compile+link and skip VISIBLY when unavailable
+# (same convention as the qemu boot smoke in scripts/freestanding_ci.sh).
+find_program(curlee_cc NAMES cc gcc)
+if(NOT curlee_cc)
+  message(FATAL_ERROR "no C compiler found; cannot run i386 link smoke")
+endif()
+if(NOT curlee_ld)
+  message(FATAL_ERROR "no ld found; cannot run i386 link smoke")
+endif()
+file(WRITE "${curlee_outdir}/m32_probe.c" "int f(int a, int b) { return a + b; }\n")
+execute_process(
+  COMMAND "${curlee_cc}" -m32 -fno-pie -fno-pic -ffreestanding -fno-builtin
+          -nostdlib -std=c11 -c "${curlee_outdir}/m32_probe.c"
+          -o "${curlee_outdir}/m32_probe.o"
+  RESULT_VARIABLE _probe_cc
+  OUTPUT_VARIABLE _probe_cc_out
+  ERROR_VARIABLE _probe_cc_err
+)
+execute_process(
+  COMMAND "${curlee_ld}" -m elf_i386 -nostdlib -static
+          "${curlee_outdir}/m32_probe.o" -o "${curlee_outdir}/m32_probe.elf"
+  RESULT_VARIABLE _probe_ld
+  OUTPUT_VARIABLE _probe_ld_out
+  ERROR_VARIABLE _probe_ld_err
+)
+if(NOT _probe_cc EQUAL 0 OR NOT _probe_ld EQUAL 0)
+  message(STATUS "i386 link smoke SKIPPED: C toolchain lacks 32-bit support "
+                 "(gcc -m32: ${_probe_cc}, ld -m elf_i386: ${_probe_ld})")
+  message(STATUS "  cc output: ${_probe_cc_out}${_probe_cc_err}")
+  message(STATUS "  ld output: ${_probe_ld_out}${_probe_ld_err}")
+  return()
+endif()
+
+file(MAKE_DIRECTORY "${curlee_outdir}")
+
+# Runs `curlee build --link [--arch <arch>] -o <out> <fixture>` and fails with
+# the captured output on error.
+function(curlee_link_fixture arch elf fixture)
+  set(_args build --link -o "${elf}" "${fixture}")
+  if(NOT arch STREQUAL "")
+    list(INSERT _args 2 --arch "${arch}")
+  endif()
+  execute_process(
+    COMMAND "${curlee_binary}" ${_args}
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _out
+    ERROR_VARIABLE _err
+  )
+  if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR
+      "curlee build --link ${arch} failed for ${fixture}:\n${_out}\n${_err}")
+  endif()
+  if(NOT EXISTS "${elf}")
+    message(FATAL_ERROR "build --link did not produce ${elf}")
+  endif()
+endfunction()
+
+# Asserts the ELF class/machine via readelf -h.
+function(curlee_check_elf_class elf expect_class expect_machine)
+  execute_process(
+    COMMAND "${curlee_readelf}" -h "${elf}"
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _out
+    ERROR_VARIABLE _err
+  )
+  if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR "readelf -h failed for ${elf}:\n${_err}")
+  endif()
+  if(NOT _out MATCHES "Class:[ \t]+${expect_class}")
+    message(FATAL_ERROR
+      "expected ${expect_class} ELF for ${elf}, got:\n${_out}")
+  endif()
+  if(NOT _out MATCHES "Machine:[ \t]+${expect_machine}")
+    message(FATAL_ERROR
+      "expected machine ${expect_machine} for ${elf}, got:\n${_out}")
+  endif()
+endfunction()
+
+# Asserts which libgcc32 helper symbols are/aren't present via nm.
+function(curlee_check_helpers elf expect_present)
+  execute_process(
+    COMMAND "${curlee_nm}" "${elf}"
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _out
+    ERROR_VARIABLE _err
+  )
+  if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR "nm failed for ${elf}:\n${_err}")
+  endif()
+  foreach(_sym __muldi3 __udivdi3 __umoddi3 __udivmoddi4 __divdi3 __moddi3
+               __negdi2 __ashldi3 __lshrdi3 __ashrdi3 __cmpdi2)
+    string(REGEX MATCH "(^|\n)[0-9a-fA-F]+ [A-Za-z] ${_sym}(\n|$)" _found "${_out}")
+    if(expect_present AND NOT _found)
+      message(FATAL_ERROR "helper symbol ${_sym} missing from ${elf}:\n${_out}")
+    endif()
+    if(NOT expect_present AND _found)
+      message(FATAL_ERROR
+        "helper symbol ${_sym} unexpectedly present in ${elf} (64-bit PVH target "
+        "must not link the 32-bit helpers):\n${_out}")
+    endif()
+  endforeach()
+endfunction()
+
+# Asserts no RWX LOAD segment via readelf -l.
+function(curlee_check_no_rwx elf)
+  execute_process(
+    COMMAND "${curlee_readelf}" -l "${elf}"
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _out
+    ERROR_VARIABLE _err
+  )
+  if(NOT _rc EQUAL 0)
+    message(FATAL_ERROR "readelf -l failed for ${elf}:\n${_err}")
+  endif()
+  if(_out MATCHES "LOAD[^\n]* RWE ")
+    message(FATAL_ERROR
+      "32-bit kernel ${elf} has an RWX LOAD segment (linker.ld / -fno-pie "
+      "regression):\n${_out}")
+  endif()
+endfunction()
+
+set(_elf32 "${curlee_outdir}/kernel32.elf")
+set(_elf64 "${curlee_outdir}/kernel64.elf")
+
+# 1. 64-bit-arithmetic fixture, --arch i386: must link with the helpers.
+curlee_link_fixture("i386" "${_elf32}" "${curlee_fixture}")
+curlee_check_elf_class("${_elf32}" "ELF32" "Intel 80386")
+curlee_check_helpers("${_elf32}" TRUE)
+curlee_check_no_rwx("${_elf32}")
+
+# 2. Same fixture, default arch (x86_64 PVH): must link WITHOUT the helpers.
+curlee_link_fixture("" "${_elf64}" "${curlee_fixture}")
+curlee_check_elf_class("${_elf64}" "ELF64" "Advanced Micro Devices X86-64")
+curlee_check_helpers("${_elf64}" FALSE)
+
+# 3. U64-only fixture (uint64_t but no int64_t in the emitted C), --arch i386:
+#    the auto-link gate must still link the helpers via the uint64_t clause.
+#    32-bit-only: x86_64 never links the helpers, so the extern __udivdi3
+#    call would be an undefined symbol there (not asserted).
+if(NOT curlee_fixture_u64_only STREQUAL "")
+  set(_elf32_u64 "${curlee_outdir}/kernel32_u64only.elf")
+  curlee_link_fixture("i386" "${_elf32_u64}" "${curlee_fixture_u64_only}")
+  curlee_check_elf_class("${_elf32_u64}" "ELF32" "Intel 80386")
+  curlee_check_helpers("${_elf32_u64}" TRUE)
+  curlee_check_no_rwx("${_elf32_u64}")
+endif()
+
+# 4. No-64-bit fixture (neither int64_t nor uint64_t in the emitted C): the
+#    gate must NOT link the helpers on i386 (and a stale curlee_libgcc32.o
+#    from an earlier i386 build into the same output dir is dropped), and
+#    x86_64 is unchanged.
+if(NOT curlee_fixture_no64 STREQUAL "")
+  set(_elf32_no64 "${curlee_outdir}/kernel32_no64.elf")
+  set(_elf64_no64 "${curlee_outdir}/kernel64_no64.elf")
+  curlee_link_fixture("i386" "${_elf32_no64}" "${curlee_fixture_no64}")
+  curlee_check_elf_class("${_elf32_no64}" "ELF32" "Intel 80386")
+  curlee_check_helpers("${_elf32_no64}" FALSE)
+  curlee_link_fixture("" "${_elf64_no64}" "${curlee_fixture_no64}")
+  curlee_check_elf_class("${_elf64_no64}" "ELF64" "Advanced Micro Devices X86-64")
+  curlee_check_helpers("${_elf64_no64}" FALSE)
+endif()
+
+message(STATUS "i386 link smoke OK: ${_elf32} (helpers linked), "
+               "${_elf64} (no helpers)")

--- a/runtime/crt0_i386.S
+++ b/runtime/crt0_i386.S
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+//
+// curlee 32-bit boot stub (crt0_i386.S)
+//
+// Entry point for a curlee kernel built with `curlee build --link --arch i386`.
+// This is the 32-bit counterpart of crt0.S: it replaces libc's crt0 entirely
+// (no libc, no CRT, no startup dependencies) for a FULLY 32-bit ELF
+// (ELFCLASS32, i386) image.
+//
+// Why a separate stub: the 64-bit crt0.S switches to long mode, but a kernel
+// whose curlee_main is compiled with -m32 must stay in 32-bit protected mode.
+// The 32-bit image is used by 32-bit-only boot paths (e.g. GRUB/ISO builds
+// whose boot info pointer is only guaranteed in %ebx for 32-bit entries).
+//
+// Responsibilities, in order:
+//   1. Zero the .bss section (symbols __bss_start / __bss_end from linker.ld).
+//   2. Set the stack pointer to __stack_top (a static .bss-reserved region).
+//   3. Call curlee_main (the codegen entry point; see codegen.cpp).
+//   4. On return, disable interrupts and halt forever (deterministic exit).
+//
+// Entry modes:
+//   - multiboot2 (GRUB, and QEMU's multiboot loader): entered in 32-bit
+//     protected mode with paging off; %ebx holds the multiboot2 info pointer
+//     (a custom boot stub may capture it — see the joeos GRUB path).
+//   - QEMU PVH `-kernel` loader: the XEN_ELFNOTE_PHYS32_ENTRY note below is
+//     required for qemu to boot an uncompressed ELF via -kernel (multiboot2
+//     alone is NOT accepted by the qemu -kernel loader); the loader enters in
+//     32-bit protected mode and jumps to _start.
+
+.code32
+// Optional multiboot2 header (magic 0xE85250D6) for GRUB.
+.section .multiboot2, "a"
+.align 8
+multiboot2_header:
+    .long 0xE85250D6              // magic: multiboot2
+    .long 0                       // architecture: i386 (protected mode, 32-bit)
+    .long multiboot2_header_end - multiboot2_header
+    .long -(0xE85250D6 + 0 + (multiboot2_header_end - multiboot2_header)) // checksum
+    // End tag.
+    .word 0                       // type: end
+    .word 0                       // flags
+    .long 8                       // size
+multiboot2_header_end:
+
+// PVH ELF note: XEN_ELFNOTE_PHYS32_ENTRY (type 18), entry = _start. QEMU
+// uses this to boot an uncompressed ELF via -kernel (the multiboot2 header
+// alone is not enough — see the header comment).
+.section .note.Xen, "a", @note
+.balign 4
+.long 2f - 1f                  // namesz
+.long 4f - 3f                  // descsz
+.long 18                       // XEN_ELFNOTE_PHYS32_ENTRY
+1:
+.asciz "Xen"
+2:
+.balign 4
+3:
+.long _start                   // physical entry point (< 4 GiB)
+4:
+.balign 4
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    // Zero .bss (32-bit addressing, no paging).
+    movl $__bss_start, %edi
+    movl $__bss_end, %ecx
+    subl %edi, %ecx
+    xorl %eax, %eax
+1:
+    testl %ecx, %ecx
+    jz 2f
+    movb %al, (%edi)
+    incl %edi
+    decl %ecx
+    jmp 1b
+2:
+    // Set stack, call the entry point, halt forever.
+    movl $__stack_top, %esp
+    xorl %ebp, %ebp
+    call curlee_main
+    cli
+3:
+    hlt
+    jmp 3b
+
+.size _start, . - _start
+
+.section .note.GNU-stack, "", @progbits

--- a/runtime/libgcc32_helpers.c
+++ b/runtime/libgcc32_helpers.c
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+//
+// libgcc32_helpers.c — bundled 32-bit libgcc-ABI helpers for the curlee
+// freestanding target (runtime/).
+//
+// The curlee codegen emits int64_t/uint64_t arithmetic (Int -> int64_t,
+// U64 -> uint64_t). Compiled with -m32 (i386), GCC lowers 64-bit
+// multiply/divide/modulo/shift to calls into libgcc runtime helpers
+// (__muldi3 / __udivdi3 / ...) that a freestanding build (-ffreestanding
+// -fno-builtin -nostdlib) never links, because libgcc is not part of the
+// image. `curlee build --link --arch i386` therefore compiles and links
+// THIS file automatically when the emitted C uses 64-bit integer types,
+// so downstream projects never have to provide their own copy.
+//
+// The 64-bit PVH target (x86_64) has native int64_t arithmetic and never
+// needs these helpers; this file is i386-only.
+//
+// Semantics match libgcc's runtime ABI (GCC's documented helper contracts).
+// Every helper is implemented with 32-bit primitives only (unsigned int and
+// pairs of them) so that, when this file is compiled for i386, the helpers
+// themselves never emit another 64-bit libgcc call — no recursion. The
+// single-word 64/32 division uses the i386 `divl` instruction directly for
+// the same reason.
+//
+// Defined behavior for this runtime: 64-bit divide-by-zero returns 0 (and
+// modulo returns the dividend), matching the reference semantics the Curlee
+// freestanding kernels have shipped with. The verifier already rejects
+// division by zero at the Curlee level; this is belt-and-braces for the
+// freestanding C.
+
+typedef unsigned int        u32;
+typedef int                 s32;
+typedef unsigned long long  u64;
+typedef long long           s64;
+
+// ---------------------------------------------------------------------------
+// 64-bit multiply (low 64 bits of the product).
+// ---------------------------------------------------------------------------
+u64 __muldi3(u64 a, u64 b)
+{
+    u32 a0 = (u32)a;
+    u32 a1 = (u32)(a >> 32);
+    u32 b0 = (u32)b;
+    u32 b1 = (u32)(b >> 32);
+
+    // a0*b0 computed exactly via 16-bit halves (no 32-bit overflow):
+    //   a0*b0 = a0l*b0l + (a0l*b0h + a0h*b0l) << 16 + (a0h*b0h) << 32
+    u32 a0l = a0 & 0xFFFFu, a0h = a0 >> 16;
+    u32 b0l = b0 & 0xFFFFu, b0h = b0 >> 16;
+    u64 t = (u64)(a0l * b0l)
+          + (((u64)(a0l * b0h) + (u64)(a0h * b0l)) << 16)
+          + ((u64)(a0h * b0h) << 32);
+
+    // Cross terms contribute only their low 32 bits (mod 2^64).
+    u32 cross = a0 * b1 + a1 * b0;
+
+    return t + ((u64)cross << 32);
+}
+
+// ---------------------------------------------------------------------------
+// Unsigned 64/64 division (+ optional remainder). The quotient (and, when
+// requested, remainder) of n / d.
+//
+// d == 0 is defined behavior for this runtime: quotient 0, remainder n.
+// ---------------------------------------------------------------------------
+static u64 udivmoddi4_impl(u64 n, u64 d, u64* rp)
+{
+    u32 n0 = (u32)n, n1 = (u32)(n >> 32);
+    u32 d0 = (u32)d, d1 = (u32)(d >> 32);
+
+    // Divide by zero: defined (0 / dividend) for this runtime.
+    if (d1 == 0 && d0 == 0)
+    {
+        if (rp)
+        {
+            *rp = n;
+        }
+        return 0;
+    }
+
+    if (d1 == 0)
+    {
+        // Single-word divisor: the quotient fits in two 32-bit words.
+        if (n1 < d0)
+        {
+            // One divl: (n1:n0) / d0; quotient < 2^32 because n1 < d0.
+            u32 q, r;
+            __asm__ volatile("divl %4" : "=a"(q), "=d"(r) : "0"(n0), "1"(n1), "r"(d0));
+            if (rp)
+            {
+                *rp = (u64)r;
+            }
+            return (u64)q;
+        }
+        else
+        {
+            // Two divls: q1 = n1/d0, r1 = n1%d0 (EDX:EAX = 0:n1), then
+            // q0 = (r1:n0)/d0, r0 = (r1:n0)%d0.
+            u32 q1, r1, q0, r0;
+            __asm__ volatile("divl %4" : "=a"(q1), "=d"(r1) : "0"(n1), "1"(0), "r"(d0));
+            __asm__ volatile("divl %4" : "=a"(q0), "=d"(r0) : "0"(n0), "1"(r1), "r"(d0));
+            if (rp)
+            {
+                *rp = (u64)r0;
+            }
+            return ((u64)q1 << 32) | q0;
+        }
+    }
+
+    // General case: 65-bit restoring long division, 32-bit ops only.
+    {
+        u32 r_hi = 0, r_lo = 0; // 64-bit remainder accumulator
+        u32 r_ovf = 0;          // bit 64 of the accumulator
+        u32 q_hi = 0, q_lo = 0;
+        int i;
+        for (i = 63; i >= 0; --i)
+        {
+            u32 bit = (i >= 32) ? ((n1 >> (i - 32)) & 1u) : ((n0 >> i) & 1u);
+            u32 new_ovf = r_hi >> 31;
+            r_hi = (r_hi << 1) | (r_lo >> 31);
+            r_lo = (r_lo << 1) | bit;
+            r_ovf = new_ovf;
+            {
+                int ge = r_ovf; // r >= 2^64 >= d -> definitely greater
+                if (!ge)
+                {
+                    if (r_hi > d1)
+                    {
+                        ge = 1;
+                    }
+                    else if (r_hi < d1)
+                    {
+                        ge = 0;
+                    }
+                    else
+                    {
+                        ge = (r_lo >= d0);
+                    }
+                }
+                if (ge)
+                {
+                    u32 borrow = (r_lo < d0) ? 1u : 0u;
+                    r_lo -= d0;
+                    r_hi = r_hi - d1 - borrow; // exact mod 2^64 (r_ovf covers the top)
+                    r_ovf = 0;
+                    if (i >= 32)
+                    {
+                        q_hi |= (1u << (i - 32));
+                    }
+                    else
+                    {
+                        q_lo |= (1u << i);
+                    }
+                }
+            }
+        }
+        if (rp)
+        {
+            *rp = ((u64)r_hi << 32) | r_lo;
+        }
+        return ((u64)q_hi << 32) | q_lo;
+    }
+}
+
+u64 __udivdi3(u64 a, u64 b)
+{
+    return udivmoddi4_impl(a, b, 0);
+}
+
+u64 __umoddi3(u64 a, u64 b)
+{
+    u64 r;
+    udivmoddi4_impl(a, b, &r);
+    return r;
+}
+
+u64 __udivmoddi4(u64 a, u64 b, u64* rp)
+{
+    return udivmoddi4_impl(a, b, rp);
+}
+
+// ---------------------------------------------------------------------------
+// Signed wrappers (sign-magnitude).
+// ---------------------------------------------------------------------------
+static u64 neg_u64(u64 x)
+{
+    return 0 - x;
+}
+
+s64 __divdi3(s64 a, s64 b)
+{
+    int neg = 0;
+    u64 ua, ub, q;
+    if (a < 0)
+    {
+        ua = neg_u64((u64)a);
+        neg ^= 1;
+    }
+    else
+    {
+        ua = (u64)a;
+    }
+    if (b < 0)
+    {
+        ub = neg_u64((u64)b);
+        neg ^= 1;
+    }
+    else
+    {
+        ub = (u64)b;
+    }
+    q = udivmoddi4_impl(ua, ub, 0);
+    return neg ? (s64)neg_u64(q) : (s64)q;
+}
+
+s64 __moddi3(s64 a, s64 b)
+{
+    int neg = 0;
+    u64 ua, ub, r;
+    if (a < 0)
+    {
+        ua = neg_u64((u64)a);
+        neg ^= 1;
+    }
+    else
+    {
+        ua = (u64)a;
+    }
+    if (b < 0)
+    {
+        ub = neg_u64((u64)b);
+    }
+    else
+    {
+        ub = (u64)b;
+    }
+    udivmoddi4_impl(ua, ub, &r);
+    return neg ? (s64)neg_u64(r) : (s64)r;
+}
+
+s64 __negdi2(s64 x)
+{
+    return (s64)neg_u64((u64)x);
+}
+
+// ---------------------------------------------------------------------------
+// Variable-count 64-bit shifts (GCC emits these when a 64-bit value is
+// shifted by a runtime amount; constant-count shifts are inlined).
+// ---------------------------------------------------------------------------
+u64 __ashldi3(u64 x, int c)
+{
+    u32 lo = (u32)x, hi = (u32)(x >> 32);
+    if (c >= 64)
+    {
+        return 0;
+    }
+    if (c >= 32)
+    {
+        hi = lo << (c - 32);
+        lo = 0;
+        return ((u64)hi << 32) | lo;
+    }
+    if (c == 0)
+    {
+        return x;
+    }
+    hi = (hi << c) | (lo >> (32 - c));
+    lo = lo << c;
+    return ((u64)hi << 32) | lo;
+}
+
+u64 __lshrdi3(u64 x, int c)
+{
+    u32 lo = (u32)x, hi = (u32)(x >> 32);
+    if (c >= 64)
+    {
+        return 0;
+    }
+    if (c >= 32)
+    {
+        lo = hi >> (c - 32);
+        hi = 0;
+        return ((u64)hi << 32) | lo;
+    }
+    if (c == 0)
+    {
+        return x;
+    }
+    lo = (lo >> c) | (hi << (32 - c));
+    hi = hi >> c;
+    return ((u64)hi << 32) | lo;
+}
+
+s64 __ashrdi3(s64 x, int c)
+{
+    u32 lo = (u32)x, hi = (u32)((u64)x >> 32);
+    u32 sign = hi >> 31;
+    if (c >= 64)
+    {
+        hi = (u32)(0u - sign);
+        lo = hi;
+        return (s64)(((u64)hi << 32) | lo);
+    }
+    if (c >= 32)
+    {
+        lo = (u32)((s32)hi >> (c - 32));
+        hi = (u32)(0u - sign);
+        return (s64)(((u64)hi << 32) | lo);
+    }
+    if (c == 0)
+    {
+        return x;
+    }
+    lo = (lo >> c) | (hi << (32 - c));
+    hi = (u32)((s32)hi >> c);
+    return (s64)(((u64)hi << 32) | lo);
+}
+
+// ---------------------------------------------------------------------------
+// 64-bit comparison (some GCC versions emit this for 64-bit compares).
+// Returns >0, 0, <0 like memcmp.
+// ---------------------------------------------------------------------------
+s64 __cmpdi2(s64 a, s64 b)
+{
+    u32 a0 = (u32)a, a1 = (u32)((u64)a >> 32);
+    u32 b0 = (u32)b, b1 = (u32)((u64)b >> 32);
+    if (a1 != b1)
+    {
+        return ((s32)a1 > (s32)b1) ? 1 : -1;
+    }
+    if (a0 != b0)
+    {
+        return (a0 > b0) ? 1 : -1;
+    }
+    return 0;
+}

--- a/runtime/linker.ld
+++ b/runtime/linker.ld
@@ -36,6 +36,12 @@ SECTIONS
         *(.data .data.*)
     }
 
+    /* Start .bss on a fresh page so GNU ld emits a separate RW LOAD segment
+     * (otherwise a small .bss/.stack adjacent to .text collapses into one
+     * RWX LOAD segment, which ld warns about). The 64-bit PVH layout is
+     * unchanged: its .bss already landed on a page boundary. */
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+
     .bss (NOLOAD) : {
         __bss_start = .;
         *(.bss .bss.*)

--- a/src/cli/cli_impl.ipp
+++ b/src/cli/cli_impl.ipp
@@ -2002,14 +2002,14 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
     // the gate: any program with int64_t/uint64_t MAY reference a helper, and
     // linking a few unused (dead) helper functions when it does not is
     // harmless (issue #288). The 64-bit PVH target never links them.
-    // GCOVR_EXCL_LINE below: the find("uint64_t") disjunct only runs when
-    // find("int64_t") already failed (|| short-circuit), but the token
-    // "uint64_t" embeds the substring "int64_t", so that disjunct's "found"
-    // branch can never fire for emitted C; all reachable branches are covered
-    // by the i386 link smoke fixtures (kernel_libgcc32{,_u64_only,_no64}).
-    const bool needs_libgcc32 =
-        is_i386 && (c_source.find("int64_t") != std::string::npos || // GCOVR_EXCL_LINE
-                    c_source.find("uint64_t") != std::string::npos);
+    //
+    // A single find("int64_t") is sufficient: the codegen maps Int -> int64_t
+    // and U64 -> uint64_t, and the token "uint64_t" embeds the substring
+    // "int64_t" (u|int64_t), so any emitted C containing uint64_t also
+    // matches the int64_t check. A separate find("uint64_t") disjunct would
+    // be dead code (it could never be the deciding branch) — see the
+    // kernel_libgcc32_u64_only.curlee fixture header.
+    const bool needs_libgcc32 = is_i386 && c_source.find("int64_t") != std::string::npos;
     if (!needs_libgcc32)
     {
         // Drop a stale helper object from a previous build into the same

--- a/src/cli/cli_impl.ipp
+++ b/src/cli/cli_impl.ipp
@@ -99,13 +99,18 @@ void print_usage(std::ostream& out)
     out << "  curlee run [--fuel <n>] [--seed <n>] [--profile] [--profile-format <text|json>] "
            "[--bundle <file.bundle>] [--cap <capability>]... <file.curlee>\n";
     out << "  curlee <lex|parse|check|run|build> [--diag-format <text|json>] ...\n";
-    out << "  curlee build [--target freestanding-c] [--link] [-o out] <entry.curlee>\n";
+    out << "  curlee build [--target freestanding-c] [--link] [--arch <x86_64|i386>] "
+           "[-o out] <entry.curlee>\n";
     out << "    --target freestanding-c: emit freestanding C for the verified program\n";
     out << "      (the only supported target; no hosted builtins: no print, no String,\n";
     out << "      no Vec. The verification gate applies: no proof, no build).\n";
     out << "    --link: produce a bootable kernel ELF (kernel.elf) by compiling the\n";
-    out << "            emitted C + runtime/crt0.S and linking with runtime/linker.ld\n";
-    out << "            (requires a C compiler and ld; x86-64 multiboot2 image)\n";
+    out << "            emitted C + the runtime boot stub and linking with\n";
+    out << "            runtime/linker.ld (requires a C compiler and ld)\n";
+    out << "    --arch <arch>: kernel architecture for --link; x86_64 (default,\n";
+    out << "            multiboot2/PVH 64-bit) or i386 (fully 32-bit ELF; the bundled\n";
+    out << "            libgcc32 helpers are linked automatically when the emitted C\n";
+    out << "            uses 64-bit arithmetic, so no downstream libgcc32.c is needed)\n";
     out << "    -o <path>: output path (default out.c; --link requires -o).\n";
     out << "  curlee run --cap phys.mem <file.curlee>  # phys.mem is freestanding-only\n";
     out << "    phys.mem: grants Phys<T> read()/write() MMIO access, the runtime-address\n";
@@ -130,17 +135,26 @@ void print_build_usage(std::ostream& out)
            "ELF).\n\n";
     out << "usage:\n";
     out << "  curlee build [--target freestanding-c] [-o <path>] <entry.curlee>\n";
-    out << "  curlee build [--target freestanding-c] --link -o <kernel.elf> <entry.curlee>\n\n";
+    out << "  curlee build [--target freestanding-c] --link [--arch <x86_64|i386>] "
+           "-o <kernel.elf> <entry.curlee>\n\n";
     out << "The full check pipeline runs first (lex -> parse -> resolve -> type-check -> "
-           "verify).\n";
+            "verify).\n";
     out << "The verification gate applies: no proof, no build (nothing is emitted on failure).\n\n";
     out << "flags:\n";
     out << "  --target <target>   codegen target; the only supported value is `freestanding-c`\n";
     out << "                      (default). Other targets are rejected.\n";
     out << "  --link              additionally compile the emitted C with\n";
     out << "                      `cc -ffreestanding -fno-builtin -nostdlib -c`, assemble\n";
-    out << "                      runtime/crt0.S, and link with runtime/linker.ld into a\n";
-    out << "                      bootable x86-64 multiboot2 kernel ELF. Requires -o.\n";
+    out << "                      the runtime boot stub (runtime/crt0.S for x86_64,\n";
+    out << "                      runtime/crt0_i386.S for i386), and link with\n";
+    out << "                      runtime/linker.ld into a bootable kernel ELF. Requires -o.\n";
+    out << "  --arch <arch>       kernel architecture for --link: x86_64 (default;\n";
+    out << "                      multiboot2/PVH 64-bit ELF) or i386 (fully 32-bit ELF,\n";
+    out << "                      `-m32` + `ld -m elf_i386`). On i386, when the emitted C\n";
+    out << "                      uses 64-bit integer arithmetic, the bundled libgcc-ABI\n";
+    out << "                      helpers (runtime/libgcc32_helpers.c) are compiled and\n";
+    out << "                      linked automatically — downstream projects never provide\n";
+    out << "                      their own libgcc32.c (issue #288).\n";
     out << "  -o <path>           output path (default: out.c). `-o -` writes the C to stdout.\n";
     out << "  --root <dir>        resolve the entry file relative to <dir>.\n";
     out << "  --stdlib-root <dir> additional stdlib search root (repeatable).\n\n";
@@ -1867,13 +1881,20 @@ int cmd_fmt(const std::string& path, bool check)
 // freestanding C (default) or, with --link, produces a bootable kernel ELF:
 //
 //   verify -> codegen to C -> cc -ffreestanding -fno-builtin -nostdlib -c ->
-//   assemble crt0.S -> ld -nostdlib -T runtime/linker.ld -> kernel.elf
+//   assemble crt0.S (x86_64) or crt0_i386.S (i386) ->
+//   ld -nostdlib -T runtime/linker.ld -> kernel.elf
+//
+// On the 32-bit target (--arch i386) the emitted C is compiled with -m32 and,
+// when it uses 64-bit integer types (int64_t/uint64_t, which GCC lowers to
+// libgcc-ABI helper calls on i386), the bundled runtime/libgcc32_helpers.c is
+// compiled and linked automatically (issue #288). The 64-bit PVH target has
+// native int64_t arithmetic and never links the helpers.
 //
 // On verification or codegen failure prints diagnostics and exits non-zero
 // without writing an output file.
 int cmd_build(const std::string& entry_path, const std::string& output_path,
               const std::vector<std::filesystem::path>& stdlib_roots, bool to_stdout, bool link,
-              DiagOutputFormat diag_format)
+              const std::string& arch, DiagOutputFormat diag_format)
 {
     std::string c_source;
     const int rc =
@@ -1954,9 +1975,14 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
         return fs::path("runtime") / name;
     };
 
-    const fs::path crt0 = runtime_file("crt0.S");
+    const bool is_i386 = (arch == "i386");
+
+    // The 32-bit target uses its own boot stub: crt0.S switches to long mode
+    // (64-bit kernel), crt0_i386.S stays in 32-bit protected mode.
+    const fs::path crt0 = runtime_file(is_i386 ? "crt0_i386.S" : "crt0.S");
     const fs::path linker_script = runtime_file("linker.ld");
     const fs::path rt_c = runtime_file("rt.c");
+    const fs::path libgcc32_c = runtime_file("libgcc32_helpers.c");
     if (!fs::exists(crt0))
     {
         std::cerr << "error: build --link: boot stub not found: " << crt0.string() << "\n";
@@ -1969,6 +1995,30 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
         return kExitError;
     }
 
+    // On i386, GCC lowers 64-bit multiply/divide/modulo/shift on int64_t to
+    // calls into libgcc-ABI helpers (__muldi3/__udivdi3/...). The freestanding
+    // build never links libgcc, so the bundled libgcc32_helpers.c must provide
+    // them. A simple "does the emitted C use 64-bit integer types" check is
+    // the gate: any program with int64_t/uint64_t MAY reference a helper, and
+    // linking a few unused (dead) helper functions when it does not is
+    // harmless (issue #288). The 64-bit PVH target never links them.
+    // GCOVR_EXCL_LINE below: the find("uint64_t") disjunct only runs when
+    // find("int64_t") already failed (|| short-circuit), but the token
+    // "uint64_t" embeds the substring "int64_t", so that disjunct's "found"
+    // branch can never fire for emitted C; all reachable branches are covered
+    // by the i386 link smoke fixtures (kernel_libgcc32{,_u64_only,_no64}).
+    const bool needs_libgcc32 =
+        is_i386 && (c_source.find("int64_t") != std::string::npos || // GCOVR_EXCL_LINE
+                    c_source.find("uint64_t") != std::string::npos);
+    if (!needs_libgcc32)
+    {
+        // Drop a stale helper object from a previous build into the same
+        // output directory (e.g. an --arch i386 link followed by an x86_64
+        // link), so a 32-bit object can never leak into a 64-bit link.
+        std::error_code ec;
+        fs::remove(fs::path(output_path).parent_path() / "curlee_libgcc32.o", ec);
+    }
+
     // Scratch files live next to the output (same filesystem).
     fs::path workdir = fs::path(output_path).parent_path();
     if (workdir.empty())
@@ -1979,6 +2029,7 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
     const fs::path kernel_o = workdir / "curlee_kernel.o";
     const fs::path crt0_o = workdir / "curlee_crt0.o";
     const fs::path rt_o = workdir / "curlee_rt.o";
+    const fs::path libgcc32_o = workdir / "curlee_libgcc32.o";
 
     auto fail = [&](const std::string& msg)
     {
@@ -1988,6 +2039,7 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
         fs::remove(kernel_o, ec);
         fs::remove(crt0_o, ec);
         fs::remove(rt_o, ec);
+        fs::remove(libgcc32_o, ec);
         return kExitError;
     };
 
@@ -2006,6 +2058,14 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
     const std::string ld = std::getenv("LD") != nullptr ? std::getenv("LD") : "ld";
     const fs::path rt_dir = runtime_file("rt.h").parent_path();
 
+    // Architecture-specific flags: -m32 for i386 (plus -fno-pie -fno-pic, so
+    // no .got.plt/PIC thunks land in the kernel image — the kernel is not
+    // position-independent, and a writable .got.plt in the .text segment would
+    // collapse into a single RWX LOAD segment, which ld warns about), and
+    // `ld -m elf_i386` so the output is a fully 32-bit ELF.
+    const std::string arch_cc_flags = is_i386 ? " -m32 -fno-pie -fno-pic " : " ";
+    const std::string arch_ld_flags = is_i386 ? "-m elf_i386 " : "";
+
     // 1. Compile the generated kernel C freestanding. The kernel is compiled
     //    with -mno-sse -mno-sse2: the boot stub (crt0.S) never enables SSE
     //    (CR4.OSFXSR), and the emitted C is pure scalar code that never needs
@@ -2015,9 +2075,8 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
     {
         const std::string cmd = shell_quote(cc) +
                                 " -ffreestanding -fno-builtin -nostdlib -std=c11 "
-                                "-mno-sse -mno-sse2 "
-                                "-I" +
-                                shell_quote(rt_dir.string()) + " -c " +
+                                "-mno-sse -mno-sse2 " +
+                                arch_cc_flags + "-I" + shell_quote(rt_dir.string()) + " -c " +
                                 shell_quote(kernel_c.string()) + " -o " +
                                 shell_quote(kernel_o.string());
         if (!run_shell(cmd))
@@ -2031,35 +2090,67 @@ int cmd_build(const std::string& entry_path, const std::string& output_path,
     {
         const std::string cmd = shell_quote(cc) +
                                 " -ffreestanding -fno-builtin -nostdlib -std=c11 "
-                                "-mno-sse -mno-sse2 "
-                                "-I" +
-                                shell_quote(rt_dir.string()) + " -c " + shell_quote(rt_c.string()) +
-                                " -o " + shell_quote(rt_o.string());
+                                "-mno-sse -mno-sse2 " +
+                                arch_cc_flags + "-I" + shell_quote(rt_dir.string()) + " -c " +
+                                shell_quote(rt_c.string()) + " -o " + shell_quote(rt_o.string());
         if (!run_shell(cmd))
         {
             return fail("C compile of runtime failed");
         }
     }
 
-    // 3. Assemble the boot stub (crt0.S).
+    // 3. On i386, compile the bundled libgcc-ABI helpers (libgcc32_helpers.c)
+    //    when the emitted C uses 64-bit integer types. The helpers use 32-bit
+    //    primitives only, so they never recursively emit another 64-bit libgcc
+    //    call (issue #288).
+    if (needs_libgcc32)
+    {
+        // The helpers ship with the runtime and the runtime dir is fixed at
+        // compile time, so the file is always present (install-error only).
+        if (!fs::exists(libgcc32_c)) // GCOVR_EXCL_LINE
+        {
+            return fail("libgcc32 helpers not found: " + libgcc32_c.string()); // GCOVR_EXCL_LINE
+        }
+        const std::string cmd = shell_quote(cc) +
+                                " -ffreestanding -fno-builtin -nostdlib -std=c11 "
+                                "-mno-sse -mno-sse2 " +
+                                arch_cc_flags + "-I" + shell_quote(rt_dir.string()) + " -c " +
+                                shell_quote(libgcc32_c.string()) + " -o " +
+                                shell_quote(libgcc32_o.string());
+        // Only a toolchain that compiles the kernel and rt.c but fails on
+        // exactly this file reaches here (environment-failure only).
+        if (!run_shell(cmd)) // GCOVR_EXCL_LINE
+        {
+            return fail("C compile of libgcc32 helpers failed"); // GCOVR_EXCL_LINE
+        }
+    }
+
+    // 4. Assemble the boot stub (crt0.S / crt0_i386.S).
     {
         const std::string cmd = shell_quote(as) + " -ffreestanding -fno-builtin -nostdlib -c " +
-                                shell_quote(crt0.string()) + " -o " + shell_quote(crt0_o.string());
+                                arch_cc_flags + shell_quote(crt0.string()) + " -o " +
+                                shell_quote(crt0_o.string());
         if (!run_shell(cmd))
         {
             return fail("assembly of boot stub failed");
         }
     }
 
-    // 4. Link with the linker script into a bootable ELF.
+    // 5. Link with the linker script into a bootable ELF.
     {
         std::string objs = shell_quote(kernel_o.string());
         if (fs::exists(rt_o))
         {
             objs += " " + shell_quote(rt_o.string());
         }
+        // When needs_libgcc32 is set the object was just compiled into this
+        // same workdir above, so it can never be missing here (defensive).
+        if (needs_libgcc32 && fs::exists(libgcc32_o)) // GCOVR_EXCL_LINE
+        {
+            objs += " " + shell_quote(libgcc32_o.string());
+        }
         objs += " " + shell_quote(crt0_o.string());
-        const std::string cmd = shell_quote(ld) + " -nostdlib -static -T " +
+        const std::string cmd = shell_quote(ld) + " -nostdlib -static " + arch_ld_flags + "-T " +
                                 shell_quote(linker_script.string()) + " " + objs + " -o " +
                                 shell_quote(output_path);
         if (!run_shell(cmd))
@@ -2190,6 +2281,7 @@ int run(int argc, char** argv)
     {
         std::string target = "freestanding-c";
         std::string output = "out.c";
+        std::string arch = "x86_64";
         bool to_stdout = false;
         bool link = false;
         bool output_explicit = false;
@@ -2251,6 +2343,36 @@ int run(int argc, char** argv)
             if (a == "--link")
             {
                 link = true;
+                ++i;
+                continue;
+            }
+
+            // `--arch` selects the kernel architecture for --link: x86_64
+            // (default, 64-bit PVH/multiboot2) or i386 (fully 32-bit ELF,
+            // auto-links the bundled libgcc32 helpers — issue #288).
+            if (a == "--arch")
+            {
+                if (i + 1 >= args.size())
+                {
+                    std::cerr << "error: expected arch after --arch\n\n";
+                    print_usage(std::cerr);
+                    return kExitUsage;
+                }
+                arch = std::string(args[i + 1]);
+                i += 2;
+                continue;
+            }
+
+            if (a.starts_with("--arch="))
+            {
+                const auto value = a.substr(std::string_view("--arch=").size());
+                if (value.empty())
+                {
+                    std::cerr << "error: expected arch after --arch=\n\n";
+                    print_usage(std::cerr);
+                    return kExitUsage;
+                }
+                arch = std::string(value);
                 ++i;
                 continue;
             }
@@ -2367,6 +2489,14 @@ int run(int argc, char** argv)
             return kExitUsage;
         }
 
+        if (arch != "x86_64" && arch != "i386")
+        {
+            std::cerr << "error: unsupported build arch: " << arch
+                      << " (supported: x86_64, i386)\n\n";
+            print_usage(std::cerr);
+            return kExitUsage;
+        }
+
         // `--link` produces a kernel ELF: it needs an explicit output path so
         // the user cannot accidentally overwrite a default `out.c` with an ELF.
         if (link && !output_explicit)
@@ -2383,7 +2513,7 @@ int run(int argc, char** argv)
             entry_path = (*root / entry_path).string();
         }
 
-        return cmd_build(entry_path, output, stdlib_roots, to_stdout, link, diag_format);
+        return cmd_build(entry_path, output, stdlib_roots, to_stdout, link, arch, diag_format);
     }
 
     if (cmd == "fmt")

--- a/tests/cli_bad_args_tests.cpp
+++ b/tests/cli_bad_args_tests.cpp
@@ -740,6 +740,82 @@ int main()
         expect_contains(err, "error: unknown command: wat", "stderr");
     }
 
+    // build --arch: missing value (issue #288).
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "build", "--arch"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for missing --arch value");
+        }
+        expect_contains(err, "error: expected arch after --arch", "stderr");
+    }
+
+    // build --arch=: empty value (issue #288).
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture({"curlee", "build", "--arch=", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for empty --arch=");
+        }
+        expect_contains(err, "error: expected arch after --arch=", "stderr");
+    }
+
+    // build --arch: unsupported value, both split and --arch= forms (issue #288).
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture(
+            {"curlee", "build", "--arch", "arm64", "-o", "out.elf", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for unsupported --arch value");
+        }
+        expect_contains(err, "error: unsupported build arch: arm64", "stderr");
+    }
+    {
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture(
+            {"curlee", "build", "--arch=arm64", "-o", "out.elf", "x.curlee"}, out, err);
+        if (rc != 2)
+        {
+            fail("expected usage exit code for unsupported --arch= value");
+        }
+        expect_contains(err, "error: unsupported build arch: arm64", "stderr");
+    }
+
+    // build --arch: both supported values are accepted by the parser (the
+    // build then fails on the missing entry file, not on the flag).
+    {
+        for (const std::string& arch : {std::string("x86_64"), std::string("i386")})
+        {
+            std::string out;
+            std::string err;
+            const int rc = run_cli_capture(
+                {"curlee", "build", "--arch", arch, "definitely_missing.curlee"}, out, err);
+            if (rc != 1)
+            {
+                fail("expected file-open error for --arch " + arch);
+            }
+            expect_contains(err, "error: failed to open file", "stderr");
+        }
+        {
+            std::string out;
+            std::string err;
+            const int rc = run_cli_capture(
+                {"curlee", "build", "--arch=i386", "definitely_missing.curlee"}, out, err);
+            if (rc != 1)
+            {
+                fail("expected file-open error for --arch=i386");
+            }
+            expect_contains(err, "error: failed to open file", "stderr");
+        }
+    }
+
     // build --link requires an output file (issue #256): -o must be given.
     {
         const fs::path extern_fixture =

--- a/tests/cli_bad_args_tests.cpp
+++ b/tests/cli_bad_args_tests.cpp
@@ -831,6 +831,29 @@ int main()
         expect_contains(err, "requires an output file", "stderr");
     }
 
+    // build --link: a mid-pipeline toolchain failure triggers the fail()
+    // cleanup lambda, which removes every scratch file (incl. the bundled
+    // libgcc32 object) before returning kExitError (issue #288, review round
+    // 1). Trigger it deterministically by pointing -o at a nonexistent output
+    // directory: codegen succeeds, then opening workdir/curlee_kernel.c fails
+    // and the cleanup path runs — no C compiler needed, so it is portable.
+    {
+        const fs::path missing_dir =
+            fs::temp_directory_path() / "curlee_link_missing_dir_xyz";
+        fs::remove_all(missing_dir); // ensure it does not exist
+        std::string out;
+        std::string err;
+        const int rc = run_cli_capture(
+            {"curlee", "build", "--link", "-o", (missing_dir / "kernel.elf").string(),
+             fixture.string()},
+            out, err);
+        if (rc != 1)
+        {
+            fail("expected error exit for build --link into a missing directory");
+        }
+        expect_contains(err, "error: build --link: cannot open scratch file", "stderr");
+    }
+
     std::cout << "OK\n";
     return 0;
 }

--- a/tests/codegen/kernel_libgcc32.curlee
+++ b/tests/codegen/kernel_libgcc32.curlee
@@ -1,0 +1,76 @@
+// Boot fixture for the bundled 32-bit libgcc-ABI helpers (issue #288).
+//
+// `curlee build --link --arch i386` compiles the emitted C with -m32, where
+// GCC lowers 64-bit integer arithmetic to libgcc-ABI helper calls. This
+// fixture forces 64-bit multiply / signed divide / modulo / variable-count
+// shifts / compare / negation (Int -> int64_t) plus U64 storage (uint64_t,
+// which triggers the helpers' presence in the emitted C) and emits every
+// result over serial, so the boot smoke can cross-check the 32-bit kernel
+// against the identical 64-bit PVH build of the same fixture (native
+// int64_t arithmetic, no helpers) and against a golden byte stream.
+//
+// 64-bit results are emitted as 8 little-endian bytes via curlee_putc
+// (driven by a host serial driver in the boot smoke). The two builds must
+// produce byte-identical serial output.
+//
+// The unsigned-division / divide-by-zero edge cases are covered by
+// tests/codegen/kernel_libgcc32_extern.curlee (extern calls into the
+// helpers) and by the host unit tests in tests/libgcc32_helpers_tests.cpp.
+extern fn curlee_putc(c: Int) -> Unit;
+extern fn curlee_halt() -> Unit;
+
+fn emit64(v: Int) -> Unit {
+  curlee_putc((v >> 0) & 255);
+  curlee_putc((v >> 8) & 255);
+  curlee_putc((v >> 16) & 255);
+  curlee_putc((v >> 24) & 255);
+  curlee_putc((v >> 32) & 255);
+  curlee_putc((v >> 40) & 255);
+  curlee_putc((v >> 48) & 255);
+  curlee_putc((v >> 56) & 255);
+  return;
+}
+
+fn main() -> Unit {
+  // 64-bit multiply. One operand per product is let-bound so the emitted C
+  // arithmetic is int64_t * <literal> (two in-int-range literals would
+  // multiply as C `int` and overflow before the 64-bit promotion — the
+  // codegen emits literals without an LL suffix), while the other operand
+  // stays a literal so the verifier's linear-multiplication model accepts it.
+  let m1: Int = 1000000000;
+  let m3: Int = 123456789;
+  emit64(m1 * 1000000000);
+  emit64(m3 * 987654321);
+  // Signed 64-bit divide / modulo (-> __divdi3 / __moddi3 on -m32).
+  emit64(1000000000000 / 7);
+  emit64(1000000000000 % 7);
+  emit64(-1000000000000 / 7);
+  emit64(-1000000000000 % 7);
+  emit64(9223372036854775807 / 3); // INT64_MAX / 3
+  emit64(-9223372036854775807 % 1000);
+  // Variable-count 64-bit shifts (runtime count; GCC inlines on -m32 but the
+  // helpers must still be linked for ABI completeness).
+  let c0: Int = 0;
+  let c33: Int = 33;
+  let c63: Int = 63;
+  emit64(1234567890123456789 << c33);
+  emit64(1234567890123456789 >> c63);
+  emit64(-1234567890123456789 >> c33);
+  emit64(-1234567890123456789 >> c0);
+  emit64(1234567890123456789 << c0);
+  // 64-bit compare (1/0 bytes).
+  if (1000000000000 < 2000000000000) { curlee_putc(1); } else { curlee_putc(0); }
+  if (1000000000000 > 2000000000000) { curlee_putc(1); } else { curlee_putc(0); }
+  if (-5 == -5) { curlee_putc(1); } else { curlee_putc(0); }
+  if (1234567890123456789 < -1) { curlee_putc(1); } else { curlee_putc(0); }
+  if (9223372036854775807 > 0) { curlee_putc(1); } else { curlee_putc(0); }
+  // 64-bit negation.
+  emit64(-(-9223372036854775807));
+  emit64(-(1234567890123456789));
+  // U64 storage (uint64_t in the emitted C -> helpers linked on i386).
+  let u: U64 = 1048576;
+  let u_exp: U64 = 1048576;
+  if (u == u_exp) { curlee_putc(1); } else { curlee_putc(0); }
+  curlee_halt();
+  return;
+}

--- a/tests/codegen/kernel_libgcc32_extern.curlee
+++ b/tests/codegen/kernel_libgcc32_extern.curlee
@@ -1,0 +1,68 @@
+// Boot fixture exercising the bundled libgcc32 helpers directly through
+// extern calls (issue #288).
+//
+// The Curlee language cannot express U64 arithmetic (division/modulo are
+// hard errors in the MVP type checker), so the unsigned helpers and the
+// divide-by-zero behavior are driven here through `extern fn` declarations:
+// codegen emits 1:1 identifiers, the freestanding link resolves them to the
+// bundled runtime/libgcc32_helpers.c (auto-linked by `curlee build --link
+// --arch i386` when the emitted C uses 64-bit types), and the booted kernel
+// calls them with edge-case vectors. The verifier treats extern calls as
+// trusted boundaries, so this also exercises the helpers' defined
+// divide-by-zero behavior (0 / dividend) end-to-end.
+//
+// This fixture is 32-bit-only (the 64-bit PVH target never links the
+// helpers; an explicit __udivdi3 call would be an undefined symbol there).
+// Each check emits a single byte: 1 = helper result matches the expected
+// value, 0 = mismatch.
+extern fn __udivdi3(a: U64, b: U64) -> U64;
+extern fn __umoddi3(a: U64, b: U64) -> U64;
+extern fn __divdi3(a: Int, b: Int) -> Int;
+extern fn __moddi3(a: Int, b: Int) -> Int;
+extern fn curlee_putc(c: Int) -> Unit;
+extern fn curlee_halt() -> Unit;
+
+fn main() -> Unit {
+  // Unsigned divide/modulo (single-word divisor path, operands < 2^32).
+  let a: U64 = 4000000000;
+  let b: U64 = 7;
+  let z: U64 = 0;
+  let exp_q: U64 = 571428571; // 4000000000 / 7
+  let exp_r: U64 = 3;         // 4000000000 % 7
+  let q: U64 = __udivdi3(a, b);
+  let r: U64 = __umoddi3(a, b);
+  if (q == exp_q) { curlee_putc(1); } else { curlee_putc(0); }
+  if (r == exp_r) { curlee_putc(1); } else { curlee_putc(0); }
+  // Unsigned divide-by-zero: quotient 0, remainder dividend (defined
+  // behavior for this runtime).
+  let q0: U64 = __udivdi3(a, z);
+  if (q0 == z) { curlee_putc(1); } else { curlee_putc(0); }
+  let r0: U64 = __umoddi3(a, z);
+  if (r0 == a) { curlee_putc(1); } else { curlee_putc(0); }
+  // Signed divide/modulo with a dividend >= 2^32 and a single-word divisor:
+  // exercises the two-divl path of udivmoddi4_impl (the branch that #DE'd in
+  // the old per-project reference on large dividends).
+  let big: Int = 1000000000000;
+  let d7: Int = 7;
+  let exp_dq: Int = 142857142857; // 1000000000000 / 7
+  let exp_dr: Int = 1;            // 1000000000000 % 7
+  let dq: Int = __divdi3(big, d7);
+  let dr: Int = __moddi3(big, d7);
+  if (dq == exp_dq) { curlee_putc(1); } else { curlee_putc(0); }
+  if (dr == exp_dr) { curlee_putc(1); } else { curlee_putc(0); }
+  // Signed edge cases: negative operands, INT64_MIN-scale magnitudes.
+  let nq: Int = __divdi3(-1000000000000, 7);
+  if (nq == -142857142857) { curlee_putc(1); } else { curlee_putc(0); }
+  let nm: Int = __moddi3(-1000000000000, 7);
+  if (nm == -1) { curlee_putc(1); } else { curlee_putc(0); }
+  let min3: Int = __divdi3(-9223372036854775807, 3);
+  if (min3 == -3074457345618258602) { curlee_putc(1); } else { curlee_putc(0); }
+  // Signed divide-by-zero: 0 (defined behavior for this runtime).
+  let zs: Int = 0;
+  let qz: Int = __divdi3(big, zs);
+  if (qz == 0) { curlee_putc(1); } else { curlee_putc(0); }
+  let mz: Int = __moddi3(big, zs);
+  if (mz == big) { curlee_putc(1); } else { curlee_putc(0); }
+  curlee_halt();
+  return;
+}

--- a/tests/codegen/kernel_libgcc32_u64_only.curlee
+++ b/tests/codegen/kernel_libgcc32_u64_only.curlee
@@ -1,14 +1,22 @@
-// i386-only boot fixture driving the bundled libgcc32 helpers with U64 types
-// and NO Int anywhere (issue #288). Unlike kernel_libgcc32.curlee /
-// kernel_libgcc32_extern.curlee (whose emitted C contains both int64_t and
-// uint64_t), this fixture's emitted C contains uint64_t but NO int64_t — it
-// exercises the `c_source.find("int64_t")` false / `find("uint64_t")` true
-// side of the auto-link gate in cli_impl.ipp, so the helpers must still be
-// linked (the gate is "any 64-bit type -> link the helpers").
+// i386-only boot fixture driving the bundled libgcc32 helpers from the U64
+// side (issue #288). This program uses ONLY U64 types (no Int anywhere), so
+// the emitted C contains `uint64_t` and no standalone `int64_t` tokens.
 //
-// This fixture is 32-bit-only: the 64-bit PVH target never links the
-// helpers, so an explicit __udivdi3 extern call would be an undefined symbol
-// there.
+// NOTE on the auto-link gate in cli_impl.ipp: the token "uint64_t" embeds
+// the substring "int64_t" (u|int64_t), so the gate's single
+// `c_source.find("int64_t")` check fires for ANY emitted C that contains
+// uint64_t. An earlier revision had a separate find("uint64_t") disjunct;
+// that was dead code (no emitted C can contain uint64_t without also
+// containing the int64_t substring) and was removed in review round 1 — see
+// the cli_impl.ipp gate comment.
+//
+// This fixture does NOT "exercise a uint64_t-only gate clause" — that is
+// impossible by construction. Its real job is to pin the end-to-end
+// behavior: a U64-only kernel links (the gate fires via the
+// int64_t-substring path) and boots with the bundled helpers, so unsigned
+// 64-bit divide (__udivdi3) resolves on i386. 32-bit-only: the 64-bit PVH
+// target never links the helpers, so an explicit __udivdi3 extern call would
+// be an undefined symbol there.
 extern fn __udivdi3(a: U64, b: U64) -> U64;
 extern fn curlee_halt() -> Unit;
 

--- a/tests/codegen/kernel_libgcc32_u64_only.curlee
+++ b/tests/codegen/kernel_libgcc32_u64_only.curlee
@@ -1,0 +1,22 @@
+// i386-only boot fixture driving the bundled libgcc32 helpers with U64 types
+// and NO Int anywhere (issue #288). Unlike kernel_libgcc32.curlee /
+// kernel_libgcc32_extern.curlee (whose emitted C contains both int64_t and
+// uint64_t), this fixture's emitted C contains uint64_t but NO int64_t — it
+// exercises the `c_source.find("int64_t")` false / `find("uint64_t")` true
+// side of the auto-link gate in cli_impl.ipp, so the helpers must still be
+// linked (the gate is "any 64-bit type -> link the helpers").
+//
+// This fixture is 32-bit-only: the 64-bit PVH target never links the
+// helpers, so an explicit __udivdi3 extern call would be an undefined symbol
+// there.
+extern fn __udivdi3(a: U64, b: U64) -> U64;
+extern fn curlee_halt() -> Unit;
+
+fn main() -> Unit {
+  let a: U64 = 4000000000;
+  let b: U64 = 7;
+  let q: U64 = __udivdi3(a, b);
+  let exp: U64 = 571428571; // 4000000000 / 7
+  if (q == exp) { curlee_halt(); }
+  return;
+}

--- a/tests/codegen/kernel_nolibgcc32.curlee
+++ b/tests/codegen/kernel_nolibgcc32.curlee
@@ -1,0 +1,17 @@
+// Minimal kernel with NO 64-bit integer types anywhere (issue #288). The
+// language maps every Int to int64_t and every U64 to uint64_t in the
+// emitted C, so this fixture — whose only extern takes/returns nothing and
+// whose body only calls it — produces C with neither token. It exercises the
+// auto-link gate's "no 64-bit types -> do NOT link the libgcc32 helpers"
+// side on BOTH targets:
+//   - --arch i386: needs_libgcc32 is false, so the bundled
+//     runtime/libgcc32_helpers.c is NOT compiled/linked and a stale
+//     curlee_libgcc32.o from a previous i386 build into the same output
+//     directory is dropped;
+//   - default x86_64: unchanged (helpers never linked).
+extern fn curlee_halt() -> Unit;
+
+fn main() -> Unit {
+  curlee_halt();
+  return;
+}

--- a/tests/libgcc32_helpers_tests.cpp
+++ b/tests/libgcc32_helpers_tests.cpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+//
+// Host unit tests for the bundled 32-bit libgcc-ABI helpers
+// (runtime/libgcc32_helpers.c, issue #288).
+//
+// The helpers are compiled into this x86-64 test binary and every one is
+// cross-checked against the host's native 64-bit arithmetic over a battery
+// of vectors including the edge cases the issue's verification plan lists:
+// division by zero, negative operands, and shift counts >= 32 and >= 64.
+//
+// Cases where native C arithmetic is UB are asserted against the helpers'
+// DOCUMENTED semantics instead (which is what the reference implementation
+// shipped with and what the acceptance criteria require):
+//   - 64-bit divide-by-zero: quotient 0, remainder dividend;
+//   - signed division that overflows (INT64_MIN / -1): sign-magnitude wrap
+//     (result INT64_MIN), matching the reference and x86 idiv behavior;
+//   - shifts with count >= 64: 0 (logical) / sign-fill (arithmetic right).
+//
+// The vectors also cover the single-word-divisor, two-word-divisor, and
+// general restoring-division paths of udivmoddi4_impl — including dividends
+// >= 2^32 with a small divisor, the branch that faulted (#DE) in the old
+// per-project reference implementation.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+extern "C" {
+uint64_t __muldi3(uint64_t a, uint64_t b);
+uint64_t __udivdi3(uint64_t a, uint64_t b);
+uint64_t __umoddi3(uint64_t a, uint64_t b);
+uint64_t __udivmoddi4(uint64_t a, uint64_t b, uint64_t* rp);
+int64_t __divdi3(int64_t a, int64_t b);
+int64_t __moddi3(int64_t a, int64_t b);
+int64_t __negdi2(int64_t x);
+uint64_t __ashldi3(uint64_t x, int c);
+uint64_t __lshrdi3(uint64_t x, int c);
+int64_t __ashrdi3(int64_t x, int c);
+int64_t __cmpdi2(int64_t a, int64_t b);
+}
+
+namespace
+{
+
+constexpr uint64_t kUmax = UINT64_MAX;
+constexpr int64_t kImax = INT64_MAX;
+constexpr int64_t kImin = INT64_MIN;
+constexpr uint64_t k2p32 = 1ull << 32;
+constexpr uint64_t k2p63 = 1ull << 63;
+
+int g_failures = 0;
+
+#define CHECK(cond)                                                                                \
+    do                                                                                             \
+    {                                                                                              \
+        if (!(cond))                                                                               \
+        {                                                                                          \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);                   \
+            ++g_failures;                                                                          \
+        }                                                                                          \
+    } while (0)
+
+void test_mul()
+{
+    const uint64_t vecs_a[] = {0ull, 1ull, 2ull, k2p32, k2p32 - 1, k2p32 + 1, k2p63,
+                               kUmax, (uint64_t)kImax, (uint64_t)kImin, 0xDEADBEEF12345678ull,
+                               0x0123456789ABCDEFull};
+    const uint64_t vecs_b[] = {0ull, 1ull, 3ull, 7ull, 1000000000ull, k2p32, k2p32 - 1,
+                               kUmax, (uint64_t)kImax, 0x100000001ull, 123456789ull};
+    for (const uint64_t a : vecs_a)
+    {
+        for (const uint64_t b : vecs_b)
+        {
+            CHECK(__muldi3(a, b) == a * b);
+        }
+    }
+}
+
+void test_udiv_umod()
+{
+    // b != 0: must match native unsigned 64-bit division/modulo exactly.
+    const uint64_t vecs_a[] = {0ull, 1ull, 7ull, k2p32, k2p32 - 1, k2p32 + 1, k2p63,
+                               kUmax, (uint64_t)kImax, (uint64_t)kImin, 0xDEADBEEF12345678ull};
+    const uint64_t vecs_b[] = {1ull, 2ull, 3ull, 7ull, 1000ull, 0x100000001ull, k2p32 - 1,
+                               k2p32 + 1, k2p63, kUmax, 0xFFFFFFFFull, 1000000000000ull};
+    for (const uint64_t a : vecs_a)
+    {
+        for (const uint64_t b : vecs_b)
+        {
+            if (b == 0)
+            {
+                continue;
+            }
+            // Single-word divisor with n1 >= d0 (two-divl path), single-word
+            // divisor with n1 < d0, and the general (two-word divisor) path
+            // are all covered by this matrix.
+            CHECK(__udivdi3(a, b) == a / b);
+            CHECK(__umoddi3(a, b) == a % b);
+
+            uint64_t r = 0;
+            CHECK(__udivmoddi4(a, b, &r) == a / b);
+            CHECK(r == a % b);
+            r = 0xCCCCCCCCCCCCCCCCull; // must be overwritten
+            CHECK(__udivmoddi4(a, b, &r) == a / b);
+            CHECK(r == a % b);
+        }
+    }
+
+    // Divide-by-zero: quotient 0, remainder dividend (defined behavior).
+    CHECK(__udivdi3(0, 0) == 0);
+    CHECK(__udivdi3(kUmax, 0) == 0);
+    CHECK(__udivdi3(k2p63, 0) == 0);
+    CHECK(__umoddi3(0, 0) == 0);
+    CHECK(__umoddi3(kUmax, 0) == kUmax);
+    CHECK(__umoddi3(42, 0) == 42);
+    uint64_t r = 0xDEADBEEFCAFEBABEull;
+    CHECK(__udivmoddi4(kUmax, 0, &r) == 0);
+    CHECK(r == kUmax);
+    // rp == NULL must not crash.
+    CHECK(__udivmoddi4(kUmax, 7, nullptr) == kUmax / 7);
+    CHECK(__udivmoddi4(kUmax, 0, nullptr) == 0);
+}
+
+void test_div_mod_signed()
+{
+    const int64_t vecs_a[] = {0, 1, -1, 7, -7, 1000, -1000, kImax, kImin, kImin + 1,
+                              -(int64_t)(k2p32 - 1), 1000000000000ll, -1000000000000ll,
+                              1234567890123456789ll};
+    const int64_t vecs_b[] = {1, 2, -1, 3, -3, 7, -7, 1000, -1000, kImax, k2p32 - 1, -5};
+    for (const int64_t a : vecs_a)
+    {
+        for (const int64_t b : vecs_b)
+        {
+            if (b == 0 || (a == kImin && b == -1))
+            {
+                continue; // native UB; covered by the explicit cases below
+            }
+            CHECK(__divdi3(a, b) == a / b);
+            CHECK(__moddi3(a, b) == a % b);
+        }
+    }
+
+    // Divide-by-zero: quotient 0, remainder dividend.
+    CHECK(__divdi3(0, 0) == 0);
+    CHECK(__divdi3(kImax, 0) == 0);
+    CHECK(__divdi3(kImin, 0) == 0);
+    CHECK(__moddi3(0, 0) == 0);
+    CHECK(__moddi3(42, 0) == 42);
+    CHECK(__moddi3(-42, 0) == -42);
+    CHECK(__moddi3(kImin, 0) == kImin);
+
+    // INT64_MIN / -1: |a|=2^63 / 1 = 2^63, negated -> 0x8000000000000000
+    // (sign-magnitude wrap, matching the reference semantics).
+    CHECK(__divdi3(kImin, -1) == kImin);
+    CHECK(__moddi3(kImin, -1) == 0);
+}
+
+void test_neg()
+{
+    CHECK(__negdi2(0) == 0);
+    CHECK(__negdi2(1) == -1);
+    CHECK(__negdi2(-1) == 1);
+    CHECK(__negdi2(kImax) == kImin + 1);
+    CHECK(__negdi2(kImin + 1) == kImax);
+    CHECK(__negdi2(kImin) == kImin); // 0 - INT64_MIN wraps to INT64_MIN
+    CHECK(__negdi2(1234567890123456789ll) == -1234567890123456789ll);
+}
+
+void test_shifts()
+{
+    const uint64_t x = 0xDEADBEEF12345678ull;
+    const int64_t sx = (int64_t)x;
+    for (int c = 0; c <= 70; ++c)
+    {
+        uint64_t exp_l = (c >= 64) ? 0ull : (x << c);
+        CHECK(__ashldi3(x, c) == exp_l);
+        uint64_t exp_r = (c >= 64) ? 0ull : (x >> c);
+        CHECK(__lshrdi3(x, c) == exp_r);
+        int64_t exp_ar = (c >= 64) ? (sx < 0 ? -1 : 0) : (sx >> c);
+        CHECK(__ashrdi3(sx, c) == exp_ar);
+    }
+    // Boundary patterns: 32/33/63/64 for a value with a nonzero high word.
+    const uint64_t hi = 0x8000000000000000ull;
+    CHECK(__ashldi3(hi, 32) == 0);
+    CHECK(__lshrdi3(hi, 63) == 1);
+    CHECK(__ashrdi3((int64_t)hi, 63) == -1);
+    CHECK(__ashrdi3((int64_t)hi, 64) == -1);
+    CHECK(__ashrdi3((int64_t)hi, 65) == -1);
+    CHECK(__ashrdi3(1, 64) == 0);
+}
+
+void test_cmp()
+{
+    const int64_t vecs[] = {kImin, kImin + 1, -1000, -1, 0, 1, 1000, kImax - 1, kImax};
+    for (const int64_t a : vecs)
+    {
+        for (const int64_t b : vecs)
+        {
+            const int64_t exp = (a > b) ? 1 : (a < b ? -1 : 0);
+            CHECK(__cmpdi2(a, b) == exp);
+        }
+    }
+}
+
+} // namespace
+
+int main()
+{
+    test_mul();
+    test_udiv_umod();
+    test_div_mod_signed();
+    test_neg();
+    test_shifts();
+    test_cmp();
+
+    if (g_failures != 0)
+    {
+        std::fprintf(stderr, "libgcc32_helpers_tests: %d failure(s)\n", g_failures);
+        return 1;
+    }
+    std::printf("libgcc32_helpers_tests: OK (mul/udiv/umod/div/mod/neg/shift/cmp vs native)\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes gh issue #288. `curlee build --link --arch i386` now compiles the emitted C with `-m32` and, when the C uses 64-bit integer types (`Int`/`U64` → `int64_t`/`uint64_t`, which GCC lowers to libgcc-ABI helper calls on i386), **automatically compiles and links the bundled `runtime/libgcc32_helpers.c`** — downstream projects never provide their own `libgcc32.c` again.

### What changed

- **`runtime/libgcc32_helpers.c`** — freestanding-safe implementations of all 11 libgcc-ABI helpers (`__muldi3 __udivdi3 __umoddi3 __udivmoddi4 __divdi3 __moddi3 __negdi2 __ashldi3 __lshrdi3 __ashrdi3 __cmpdi2`), built from 32-bit primitives only (no recursive libgcc calls), matching the reference semantics including divide-by-zero returning 0.
- **`runtime/crt0_i386.S`** — 32-bit protected-mode boot stub (multiboot2 header + PVH `XEN_ELFNOTE_PHYS32_ENTRY` note), the i386 counterpart of `crt0.S`.
- **`src/cli/cli_impl.ipp`** — new `--arch <x86_64|i386>` flag; `needs_libgcc32` auto-link gate (i386 && emitted C contains a 64-bit type); `-m32 -fno-pie -fno-pic` and `ld -m elf_i386` flags; a stale `curlee_libgcc32.o` from a previous i386 build is dropped when not needed; the mid-pipeline failure path removes all scratch files including `curlee_libgcc32.o`.
- **`runtime/linker.ld`** — page-align `.bss` so a small 32-bit kernel gets separate RE + RW LOAD segments (no RWX). The 64-bit PVH layout is unchanged (its `.bss` already landed on a page boundary).
- **Tests** — `curlee_i386_link_smoke` ctest (ELF32/Intel 80386, all 11 helpers present, x86_64 carries NONE, no RWX LOAD segment); boot/codegen fixtures `kernel_libgcc32{,_extern,_u64_only}.curlee` and `kernel_nolibgcc32.curlee` (pinning the gate from both sides: 64-bit types → helpers linked, no 64-bit types → not linked); host unit tests for every helper vs native 64-bit arithmetic over the issue's edge-case vectors; CLI bad-args coverage for `--arch` (missing/empty/unsupported values, both `--arch` and `--arch=` forms) and for the `--link` mid-pipeline failure path.

### The auto-link gate (one check, not two)

The gate is a single `c_source.find("int64_t")` test. The codegen maps `Int` → `int64_t` and `U64` → `uint64_t`, and the token `uint64_t` embeds the substring `int64_t`, so any emitted C that contains `uint64_t` also matches the `int64_t` check. A separate `find("uint64_t")` disjunct was added during development and is **dead code by construction** — no emitted C can contain `uint64_t` without the `int64_t` substring — so it was removed in review round 1 rather than kept as a misleading clause. The `kernel_libgcc32_u64_only.curlee` fixture (a U64-only program, no `Int`) is an end-to-end test that such a kernel still links and boots with the bundled helpers; it does not and cannot exercise a distinct "uint64_t-only" gate branch.

## Acceptance criteria — verified

1. **32-bit freestanding kernel with 64-bit multiply / signed+unsigned divide / modulo / variable-count shifts / compare links via `curlee build --link --arch i386` with NO downstream-supplied helper file.** Verified: ELF32 / Intel 80386, all 11 helpers linked (`nm`); QEMU boot (isa-debug-exit) exits 3 and the 126-byte serial stream is byte-identical to the 64-bit PVH build of the same fixture and matches all independently computed expected values.
2. **Bundled helpers produce identical results to the reference semantics** (incl. divide-by-zero → 0). Verified via the extern-only boot fixture (11 × `0x01` serial, one per helper check) and the host unit test battery (`curlee_libgcc32_helpers_tests`).
3. **64-bit PVH target unaffected.** The same fixture linked without `--arch` has zero helper symbols, and `kernel_hello` linked with the current `runtime/linker.ld` vs the pre-change one has byte-identical LOAD segments / ELF headers (same file size 7032, same section-header offset 6328).
4. **w4ffl35/joeos migration.** Verified end-to-end against the real repo (fresh clone): deleted `kernel/libgcc32.c` and changed the Makefile line to `LIBGCC32_C = $(CURLEE_RT)/libgcc32_helpers.c` — **note the plain `=`, not `:=`**. The Makefile's `CURLEE_RT` is defined further down the file (derived from `CURLEE_ROOT`/`CURLEE`), so `:=` (immediate expansion) captures it as empty and silently produces `LIBGCC32_C = /libgcc32_helpers.c`. `make verify`/`make qemu-smoke` don't catch this (neither builds `kernel-grub.elf`), but `make qemu-fb-smoke` does: `No rule to make target '/libgcc32_helpers.c'`. Independently reproduced and confirmed both ways (review round 2 finding) — with `=`, `make verify` → all gates PASS, `make qemu-smoke` → PASS, `make qemu-fb-smoke` (GRUB ISO, 32-bit path) → PASS (`FR:0..3`, `RING: 1`, `FB: 1`, `Hello World from JOE!`) with all 11 helpers linked into `kernel-grub.elf`. No toolchain code change was needed — only the documented migration recipe.

## Coverage note

The 100% coverage gate is **chronically red on `master`** independent of this branch (pre-existing gaps in `codegen.cpp`/`checker.cpp`/`cost_model.cpp`). For the lines this branch adds, the intersection of diff-added lines with the uncovered-line list is **empty at both the line level and the branch level** — checked against the gcovr HTML per-line report (line-level, which the previous round's branch-metric-only txt comparison missed), not just the txt `--txt-metric branch` list. The `fail()` cleanup lambda's `fs::remove(libgcc32_o, ec)` line (which the round-1 review flagged as line-uncovered) is now genuinely executed by a new CLI test that triggers the mid-pipeline failure path via a nonexistent output directory.

