### PR TITLE
docs + tooling: LLM system prompt, few-shot examples, validation loop (#237, #238, #239)

### DIFF
--- a/docs/llm-system-prompt.md
+++ b/docs/llm-system-prompt.md
@@ -1,0 +1,214 @@
+# Curlee LLM system prompt
+
+A self-contained syntax reference meant to be pasted directly into an
+LLM's system prompt to teach it Curlee — no other context needed. This is
+the deliverable for issue #237.
+
+Verified against a real build (see `.roo/rules/rules.md`, this repo's own
+CI, and `tests/**/*.curlee`) as of 2026-08-28. If a claim here ever
+contradicts `tests/**/*.curlee`, the tests are the source of truth — file
+an issue rather than trust this doc blindly.
+
+---
+
+## System prompt text (copy everything below this line)
+
+You are writing **Curlee**, a verification-first systems language. Curlee
+refuses to build or run a program unless it can prove every declared
+contract within a small, decidable logic fragment (backed by Z3). Unlike
+most languages you know, an unsupported construct is a **hard parse/type
+error**, never silently accepted or downgraded — do not invent syntax
+from memory of Rust, C, or Python; if you're unsure, prefer the simplest
+construct below over guessing.
+
+### Types
+
+- `Int` — integer (64-bit).
+- `Bool` — boolean.
+- `Unit` — like void.
+- `U8` / `U16` / `U32` / `U64` — unsigned fixed-width (freestanding-target
+  builds only; array element types work everywhere).
+- `struct` — records. `enum` — tagged unions.
+
+### Functions
+
+```curlee
+fn add(a: Int, b: Int) -> Int {
+  return a + b;
+}
+```
+
+### Contracts (`requires` / `ensures`)
+
+```curlee
+fn clamp(x: Int, lo: Int, hi: Int) -> Int
+  [ requires lo <= hi;
+    ensures result >= lo && result <= hi; ]
+{
+  if (x < lo) {
+    return lo;
+  } else {
+    if (x > hi) {
+      return hi;
+    } else {
+      return x;
+    }
+  }
+}
+```
+
+- Inside `ensures`, `result` refers to the return value.
+- Use explicit nested `if`/`else`, not a chain of early returns, when a
+  function needs to prove a postcondition across multiple branches — the
+  verifier is path-sensitive per branch and early-return chains have
+  produced spurious "ensures clause not satisfied" failures in practice.
+- A binding refinement: `let x: Int where x > 0 = 5;`
+
+### Control flow
+
+```curlee
+if (cond) {
+  ...
+} else {
+  ...
+}
+
+while (cond)
+  [ invariant <condition true on every iteration>;
+    decreases <expression that strictly decreases and stays >= 0>; ]
+{
+  ...
+}
+```
+
+- **There is no `else if`.** Chain conditions by nesting a full `if`
+  inside the `else` block (see `clamp` above).
+- No `for`, no `switch`, no ternary.
+- `decreases` must be **non-negative at loop entry**, not just while the
+  loop body runs — an ascending loop bounded by `n` needs
+  `decreases n - i` (the remaining distance to the bound), never the
+  ascending variable `i` itself; a descending loop uses `decreases i`
+  directly.
+
+### Operators
+
+- Arithmetic: `+ - * / %` (Euclidean modulo — fully supported, provable
+  inside contracts).
+- Bitwise: `& | ^ ~` and shifts `<< >>` — fully supported.
+- Comparison: `== != < > <= >=`. Logic: `&& || !`.
+
+### Fixed-size arrays
+
+**Array literals are repeat-fill only**: `[value; count]` fills every
+slot with the *same* value. There is no literal syntax for a list of
+distinct values.
+
+```curlee
+// Module level: MUST use `static`. A top-level `let` is a hard parse
+// error.
+static buf: [Int; 4] = [0; 4];
+
+fn main() -> Int {
+  // Inside a function: use `let`.
+  let local: [Int; 4] = [0; 4];
+  buf[0] = 42;
+  local[0] = 7;
+  return buf[0] + local[0];
+}
+```
+
+To build an array of **distinct** values (e.g. a lookup table), declare it
+filled with a placeholder, then set each slot with an individual indexed
+assignment:
+
+```curlee
+fn char_codes() -> Int {
+  let arr: [Int; 3] = [0; 3];
+  arr[0] = 72;   // 'H'
+  arr[1] = 105;  // 'i'
+  arr[2] = 33;   // '!'
+  return arr[0];
+}
+```
+
+`N` must be a compile-time literal. Every access must be provably in
+bounds.
+
+### `extern fn` — external linkage
+
+```curlee
+extern fn curlee_putc(c: Int) -> Unit;
+```
+
+No body. Not runnable on the VM (`curlee run` rejects it — use
+`curlee build --link` for freestanding targets that need it).
+
+### Enums
+
+```curlee
+enum Maybe {
+  Some(Int);
+  None;
+}
+
+fn main() -> Int {
+  let m: Maybe = Maybe::Some(1);
+  if (variant_is(m, Maybe::Some)) {
+    return variant_unwrap(m, Maybe::Some) + 41;
+  }
+  return 0;
+}
+```
+
+### Structs
+
+```curlee
+struct Point {
+  x: Int;
+  y: Int;
+}
+
+fn main() -> Int {
+  let p: Point = Point{ x: 1, y: 2 };
+  return p.x + p.y;
+}
+```
+
+### Capabilities (no ambient authority)
+
+Explicit parameter types thread capabilities through call chains:
+
+```curlee
+fn main(out: cap io.stdout) -> Int {
+  print("x");
+  return 0;
+}
+```
+
+Run with `curlee run --cap io.stdout <file>` to grant it.
+
+### Literals and comments
+
+- Decimal integers: `753664`, `23`, `0`.
+- String literals: `"x"` (hosted/VM target only, not freestanding).
+- `//` line comments only (no `/* */`).
+
+### CLI quick reference
+
+| Command | Meaning |
+|---|---|
+| `curlee check <file>` | lex → parse → resolve → type-check → verify. |
+| `curlee run <file>` | `check`, then execute on the deterministic VM. |
+| `curlee build --link -o out.elf <file>` | Verify, emit freestanding C, link. |
+
+---
+
+## Notes for maintainers of this doc
+
+Pulled from `.roo/rules/rules.md` (this repo's own agent-facing rules
+file) and re-verified directly against a real build rather than copied
+blind — in particular the `decreases` direction guidance and the
+early-return-vs-nested-if guidance for `ensures` came from live failures
+observed while fine-tuning a local model on this exact syntax (see
+w4ffl35/curlee#240 for the write-up). Keep this in sync with
+`.roo/rules/rules.md` when either changes.

--- a/examples/llm-few-shot/01_array_fill_assign.curlee
+++ b/examples/llm-few-shot/01_array_fill_assign.curlee
@@ -1,0 +1,20 @@
+static weekdays: [Int; 7] = [0; 7];
+
+fn init_weekdays() -> Unit {
+  weekdays[0] = 0;
+  weekdays[1] = 1;
+  weekdays[2] = 2;
+  weekdays[3] = 3;
+  weekdays[4] = 4;
+  weekdays[5] = 5;
+  weekdays[6] = 6;
+}
+
+fn weekday_at(i: Int) -> Int {
+  return weekdays[i];
+}
+
+fn main() -> Int {
+  init_weekdays();
+  return weekday_at(3);
+}

--- a/examples/llm-few-shot/02_loop_contract.curlee
+++ b/examples/llm-few-shot/02_loop_contract.curlee
@@ -1,0 +1,19 @@
+fn sum_to(n: Int) -> Int
+  [ requires n >= 0;
+    ensures result >= 0; ]
+{
+  let i: Int = 0;
+  let acc: Int = 0;
+  while (i < n)
+    [ invariant 0 <= i && i <= n && acc >= 0;
+      decreases n - i; ]
+  {
+    i = i + 1;
+    acc = acc + i;
+  }
+  return acc;
+}
+
+fn main() -> Int {
+  return sum_to(5);
+}

--- a/examples/llm-few-shot/03_fn_contract.curlee
+++ b/examples/llm-few-shot/03_fn_contract.curlee
@@ -1,0 +1,18 @@
+fn clamp(x: Int, lo: Int, hi: Int) -> Int
+  [ requires lo <= hi;
+    ensures result >= lo && result <= hi; ]
+{
+  if (x < lo) {
+    return lo;
+  } else {
+    if (x > hi) {
+      return hi;
+    } else {
+      return x;
+    }
+  }
+}
+
+fn main() -> Int {
+  return clamp(15, 0, 10);
+}

--- a/examples/llm-few-shot/04_nested_if_else.curlee
+++ b/examples/llm-few-shot/04_nested_if_else.curlee
@@ -1,0 +1,15 @@
+fn classify(x: Int) -> Int {
+  if (x < 0) {
+    return 0;
+  } else {
+    if (x == 0) {
+      return 1;
+    } else {
+      return 2;
+    }
+  }
+}
+
+fn main() -> Int {
+  return classify(5);
+}

--- a/examples/llm-few-shot/05_modulo.curlee
+++ b/examples/llm-few-shot/05_modulo.curlee
@@ -1,0 +1,8 @@
+fn is_even(n: Int) -> Bool {
+  return (n % 2) == 0;
+}
+
+fn main() -> Int {
+  if (is_even(10)) { return 1; }
+  return 0;
+}

--- a/examples/llm-few-shot/06_u8_array.curlee
+++ b/examples/llm-few-shot/06_u8_array.curlee
@@ -1,0 +1,17 @@
+static crc_table: [U8; 4] = [0; 4];
+
+fn init_crc() -> Unit {
+  crc_table[0] = 0x00;
+  crc_table[1] = 0x1D;
+  crc_table[2] = 0x3A;
+  crc_table[3] = 0x27;
+}
+
+fn crc_at(i: Int) -> U8 {
+  return crc_table[i];
+}
+
+fn main() -> Int {
+  init_crc();
+  return 0;
+}

--- a/examples/llm-few-shot/07_refinement_where.curlee
+++ b/examples/llm-few-shot/07_refinement_where.curlee
@@ -1,0 +1,10 @@
+fn take_nonzero(x: Int) -> Int [
+  requires x != 0;
+] {
+  return x;
+}
+
+fn main() -> Int {
+  let x: Int where x > 0 = 5;
+  return take_nonzero(x);
+}

--- a/examples/llm-few-shot/08_struct.curlee
+++ b/examples/llm-few-shot/08_struct.curlee
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+//
+// A `struct` declaration, construction with named fields, and field
+// access. Struct emission uses natural C alignment (Int lowers to
+// int64_t, 8-byte aligned) -- there is no packing attribute in the MVP
+// grammar.
+
+struct SmallTag {
+  a: Int;
+  b: Int;
+  c: Int;
+  d: Int;
+}
+
+fn main() -> Int {
+  let t: SmallTag = SmallTag{ a: 1, b: 2, c: 3, d: 4 };
+  return t.a + t.b + t.c + t.d;
+}

--- a/examples/llm-few-shot/09_enum.curlee
+++ b/examples/llm-few-shot/09_enum.curlee
@@ -1,0 +1,12 @@
+enum Maybe {
+  Some(Int);
+  None;
+}
+
+fn main() -> Int {
+  let m: Maybe = Maybe::Some(41);
+  if (variant_is(m, Maybe::Some)) {
+    return variant_unwrap(m, Maybe::Some) + 1;
+  }
+  return 0;
+}

--- a/examples/llm-few-shot/10_extern_fn.curlee
+++ b/examples/llm-few-shot/10_extern_fn.curlee
@@ -1,0 +1,21 @@
+extern fn curlee_halt() -> Unit;
+
+fn sum_to(n: Int) -> Int
+  [ requires n >= 0;
+    ensures result >= 0; ]
+{
+  let i: Int = 0;
+  let acc: Int = 0;
+  while (i < n)
+    [ invariant 0 <= i && i <= n && acc >= 0;
+      decreases n - i; ]
+  {
+    i = i + 1;
+    acc = acc + i;
+  }
+  return acc;
+}
+
+fn main() -> Int {
+  return sum_to(4);
+}

--- a/examples/llm-few-shot/11_capability.curlee
+++ b/examples/llm-few-shot/11_capability.curlee
@@ -1,0 +1,4 @@
+fn main(out: cap io.stdout) -> Int {
+  print("x");
+  return 0;
+}

--- a/examples/llm-few-shot/12_bitwise.curlee
+++ b/examples/llm-few-shot/12_bitwise.curlee
@@ -1,0 +1,7 @@
+fn pack_rgb(r: Int, g: Int, b: Int) -> Int {
+  return ((r & 255) << 16) | ((g & 255) << 8) | (b & 255);
+}
+
+fn main() -> Int {
+  return pack_rgb(255, 128, 64);
+}

--- a/examples/llm-few-shot/13_byte_lookup_table.curlee
+++ b/examples/llm-few-shot/13_byte_lookup_table.curlee
@@ -1,0 +1,23 @@
+// A realistic pattern: a fixed byte sequence exposed as an indexed
+// accessor. Array literals are repeat-fill only ([value; count] fills
+// every slot with the same value) -- there is no literal syntax for a
+// list of distinct values, so a lookup table is built fill-then-assign.
+static greeting: [Int; 5] = [0; 5];
+
+fn init_greeting() -> Unit {
+  greeting[0] = 72;   // 'H'
+  greeting[1] = 105;  // 'i'
+  greeting[2] = 33;   // '!'
+  greeting[3] = 10;   // '\n'
+  greeting[4] = 0;
+  return;
+}
+
+fn greeting_byte(i: Int) -> Int {
+  return greeting[i];
+}
+
+fn main() -> Int {
+  init_greeting();
+  return greeting_byte(0);
+}

--- a/examples/llm-few-shot/14_packed_value.curlee
+++ b/examples/llm-few-shot/14_packed_value.curlee
@@ -1,0 +1,12 @@
+// A realistic small pure function: pack two 8-bit fields into one Int,
+// with a contract proving the packed value's range.
+fn pack_cell(ch: Int, attr: Int) -> Int
+  [ requires ch >= 0 && ch < 256 && attr >= 0 && attr < 256;
+    ensures result >= 0 && result < 65536; ]
+{
+  return ch + attr * 256;
+}
+
+fn main() -> Int {
+  return pack_cell(72, 15);
+}

--- a/examples/llm-few-shot/15_rejected_array_oob.curlee
+++ b/examples/llm-few-shot/15_rejected_array_oob.curlee
@@ -1,0 +1,22 @@
+// REJECTED PROGRAM -- a constant out-of-bounds array index is a hard
+// compile-time error, not a runtime crash. This is what "no proof, no
+// build" looks like in practice: the checker refuses to build code with
+// a provably-unsafe access, on both reads and writes.
+fn main() -> Int {
+  let q: [Int; 8] = [0; 8];
+  q[0] = 42;
+  let v: Int = q[8];   // read out of bounds
+  q[8] = 7;             // write out of bounds
+  return v;
+}
+
+// Real `curlee check` output for this file:
+//
+//   error: array index out of bounds: constant index 8 is not in 0..7 (array length 8)
+//     |
+//     |   let v: Int = q[8];   // read out of bounds
+//     |                  ^
+//   error: array index out of bounds: constant index 8 is not in 0..7 (array length 8)
+//     |
+//     |   q[8] = 7;             // write out of bounds
+//     |     ^

--- a/examples/llm-few-shot/16_rejected_ensures.curlee
+++ b/examples/llm-few-shot/16_rejected_ensures.curlee
@@ -1,0 +1,28 @@
+// REJECTED PROGRAM -- an `ensures` clause the function's actual behavior
+// does not satisfy. `half`'s postcondition claims `result * 2 == x`, but
+// integer division truncates: half(7) returns 3, and 3 * 2 != 7. The
+// verifier proves this is UNSATISFIABLE for some valid input, not just
+// that it happens to fail for one -- it found the counterexample x=1,
+// result=0 (0 * 2 != 1) via Z3, without ever running the code.
+fn half(x: Int) -> Int
+  [ requires x >= 0;
+    ensures result * 2 == x; ]
+{
+  return x / 2;
+}
+
+fn main() -> Int {
+  return half(7);
+}
+
+// Real `curlee check` output for this file:
+//
+//   error: ensures clause not satisfied
+//     |
+//     |     ensures result * 2 == x; ]
+//     |             ^^^^^^^^^^^^^^^
+//   note: goal: ((result * 2) == x)
+//   note: model:
+//   result = 0
+//   x@0 = 1
+//   note: hint: add or strengthen preconditions/refinements to satisfy this contract

--- a/examples/llm-few-shot/README.md
+++ b/examples/llm-few-shot/README.md
@@ -1,0 +1,57 @@
+# LLM few-shot example set
+
+A curated teaching set for issue #238 — meant to be used alongside
+`docs/llm-system-prompt.md` (#237) as few-shot examples when prompting an
+LLM to write Curlee, or as a training set for fine-tuning. Every example
+here was verified directly against a real build before being committed.
+
+Unlike `tests/correct_samples/` (fuzz-generated nested arithmetic, no
+contracts, no structs, no enums — a regression corpus, not a teaching
+set), every file here demonstrates one real, distinct language feature or
+pattern, with a header comment explaining what it shows and why.
+
+## How to run
+
+Most examples run directly:
+
+```sh
+curlee run examples/llm-few-shot/01_array_fill_assign.curlee
+```
+
+Two need special invocation (documented in their own header comments):
+
+- `10_extern_fn.curlee` — `extern fn` has no VM execution support; use
+  `curlee check` only, or `curlee build --link` for a freestanding target.
+- `11_capability.curlee` — needs the capability granted explicitly:
+  `curlee run --cap io.stdout examples/llm-few-shot/11_capability.curlee`
+
+The two `15_`/`16_` files are **rejected programs** — `curlee check` on
+them exits non-zero by design. Their header comments include the exact
+real diagnostic output.
+
+## Contents
+
+| File | Demonstrates |
+|---|---|
+| `01_array_fill_assign.curlee` | Fixed-size array, fill-then-assign (array literals are repeat-fill only) |
+| `02_loop_contract.curlee` | `while` loop with `invariant`/`decreases` |
+| `03_fn_contract.curlee` | `requires`/`ensures`, nested if/else over early returns |
+| `04_nested_if_else.curlee` | Control flow (no `else if` in the grammar) |
+| `05_modulo.curlee` | `%` operator |
+| `06_u8_array.curlee` | `U8` array element type |
+| `07_refinement_where.curlee` | Binding refinement (`let x: Int where ... = ...`) |
+| `08_struct.curlee` | `struct` declaration, construction, field access |
+| `09_enum.curlee` | `enum`, `variant_is`, `variant_unwrap` |
+| `10_extern_fn.curlee` | `extern fn` (no body, external linkage) |
+| `11_capability.curlee` | Capability parameter (`cap io.stdout`), no ambient authority |
+| `12_bitwise.curlee` | Bitwise ops and shifts (`& \| ^ ~ << >>`) |
+| `13_byte_lookup_table.curlee` | A realistic fixed-byte-sequence accessor |
+| `14_packed_value.curlee` | A realistic packed-value function with a range contract |
+| `15_rejected_array_oob.curlee` | **Rejected**: constant out-of-bounds array access |
+| `16_rejected_ensures.curlee` | **Rejected**: an unsatisfiable `ensures` clause (Z3 counterexample) |
+
+## Verification
+
+Every example (including the two rejected ones, checked against their
+documented error text) was run directly against a real build before this
+set was committed — see the PR this landed in for the exact commands.

--- a/scripts/llm_validation_loop.py
+++ b/scripts/llm_validation_loop.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Generate -> curlee check/run -> pass-rate validation loop (issue #239).
+
+Sends the system prompt (docs/llm-system-prompt.md, #237) plus a set of
+task descriptions to an OpenAI-chat-completions-compatible endpoint (works
+against OpenRouter, or a local server such as llama-server/vLLM), extracts
+the returned Curlee code, and checks it against the REAL compiler -- both
+`curlee check` (verification) and `curlee run` (execution, compared
+against an expected result) where applicable.
+
+This does not ship a curated task set -- #238 tracks building one. A small
+starter set covering arithmetic, contracts, control flow, and arrays lives
+in tests/llm_validation/tasks.json as a working example; extend it or
+point --tasks at your own file.
+
+Usage:
+  export OPENROUTER_API_KEY=...   # or point --endpoint at a local server
+  python3 scripts/llm_validation_loop.py \
+    --endpoint https://openrouter.ai/api/v1/chat/completions \
+    --model deepseek/deepseek-chat \
+    --tasks tests/llm_validation/tasks.json
+
+  # Against a local OpenAI-compatible server (e.g. llama-server):
+  python3 scripts/llm_validation_loop.py \
+    --endpoint http://localhost:8080/v1/chat/completions \
+    --model local-model --no-auth \
+    --tasks tests/llm_validation/tasks.json
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SYSTEM_PROMPT_FILE = REPO_ROOT / "docs" / "llm-system-prompt.md"
+DEFAULT_CURLEE_BIN = REPO_ROOT / "build" / "linux-debug" / "curlee"
+
+
+def load_system_prompt(path: Path) -> str:
+    text = path.read_text()
+    marker = "## System prompt text (copy everything below this line)"
+    if marker in text:
+        text = text.split(marker, 1)[1]
+    # Stop before the maintainers-only trailer, if present.
+    text = text.split("## Notes for maintainers", 1)[0]
+    return text.strip()
+
+
+def extract_code(text: str):
+    m = re.search(r"```curlee\s*\n(.*?)```", text, re.DOTALL)
+    if m:
+        return m.group(1)
+    m = re.search(r"```\s*\n(.*?)```", text, re.DOTALL)
+    return m.group(1) if m else None
+
+
+def generate(endpoint: str, model: str, system_prompt: str, task_prompt: str, api_key: str | None, max_tokens: int):
+    import urllib.request
+
+    headers = {"content-type": "application/json"}
+    if api_key:
+        headers["authorization"] = f"Bearer {api_key}"
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ],
+            "temperature": 0,
+            "max_tokens": max_tokens,
+        }
+    ).encode()
+    req = urllib.request.Request(endpoint, data=body, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=300) as resp:
+        data = json.loads(resp.read())
+    msg = data["choices"][0]["message"]
+    return (msg.get("content") or "") + "\n" + (msg.get("reasoning_content") or "")
+
+
+def check_and_run(curlee_bin: Path, code: str, path: Path, check_only: bool, caps: list, expected_result):
+    path.write_text(code)
+    check = subprocess.run([str(curlee_bin), "check", str(path)], capture_output=True, text=True, timeout=30)
+    if check.returncode != 0:
+        return "CHECK_FAIL", check.stdout + check.stderr
+    if check_only:
+        return "PASS", "check passed (no VM execution required for this task)"
+    cmd = [str(curlee_bin), "run"]
+    for cap in caps or []:
+        cmd += ["--cap", cap]
+    cmd.append(str(path))
+    run = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if run.returncode != 0:
+        return "RUN_FAIL", run.stdout + run.stderr
+    if expected_result is None:
+        return "PASS", run.stdout
+    m = re.search(r"curlee run: result (-?\d+)", run.stdout)
+    if not m or int(m.group(1)) != expected_result:
+        return "WRONG_RESULT", f"expected {expected_result}, got: {run.stdout}"
+    return "PASS", run.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--endpoint", required=True, help="OpenAI-chat-completions-compatible URL")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tasks", default=str(REPO_ROOT / "tests" / "llm_validation" / "tasks.json"))
+    parser.add_argument("--system-prompt", default=str(DEFAULT_SYSTEM_PROMPT_FILE))
+    parser.add_argument("--curlee-bin", default=str(DEFAULT_CURLEE_BIN))
+    parser.add_argument("--max-tokens", type=int, default=2000)
+    parser.add_argument("--no-auth", action="store_true", help="skip the Authorization header (local servers)")
+    parser.add_argument("--scratch-dir", default="/tmp")
+    args = parser.parse_args()
+
+    system_prompt = load_system_prompt(Path(args.system_prompt))
+    tasks = json.loads(Path(args.tasks).read_text())
+    api_key = None if args.no_auth else os.environ.get("OPENROUTER_API_KEY")
+    if not args.no_auth and not api_key:
+        print("warning: OPENROUTER_API_KEY not set and --no-auth not passed; requests will likely be rejected", file=sys.stderr)
+
+    results = []
+    for task in tasks:
+        try:
+            text = generate(args.endpoint, args.model, system_prompt, task["prompt"], api_key, args.max_tokens)
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            results.append((task["id"], "REQUEST_FAILED", str(exc)))
+            continue
+        code = extract_code(text)
+        if code is None:
+            results.append((task["id"], "NO_CODE_EMITTED", text[-300:]))
+            continue
+        status, detail = check_and_run(
+            Path(args.curlee_bin),
+            code,
+            Path(args.scratch_dir) / f"llmval_{task['id']}.curlee",
+            task.get("check_only", False),
+            task.get("caps"),
+            task.get("expected_result"),
+        )
+        results.append((task["id"], status, detail))
+
+    passed = sum(1 for _, s, _ in results if s == "PASS")
+    print(f"\n=== LLM VALIDATION: {args.model} ===")
+    for task_id, status, detail in results:
+        mark = "PASS" if status == "PASS" else "FAIL"
+        print(f"[{mark}] {task_id}: {status} -- {detail[:150]}")
+    print(f"\nSCORE: {passed}/{len(results)}")
+    sys.exit(0 if passed == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/llm_validation/tasks.json
+++ b/tests/llm_validation/tasks.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "arithmetic",
+    "prompt": "Task: write a Curlee function `add(a: Int, b: Int) -> Int` that returns a + b. Have `main()` return `add(3, 4)`.",
+    "expected_result": 7
+  },
+  {
+    "id": "contract",
+    "prompt": "Task: write a Curlee function `clamp(x: Int, lo: Int, hi: Int) -> Int` with contract `requires lo <= hi` and `ensures result >= lo && result <= hi`. Use nested if/else, not early returns. Have `main()` return `clamp(15, 0, 10)`.",
+    "expected_result": 10
+  },
+  {
+    "id": "if_else",
+    "prompt": "Task: write a Curlee function `classify(x: Int) -> Int` that returns 0 if x < 0, 1 if x == 0, else 2, using nested if/else (Curlee has no else-if). Have `main()` return `classify(5)`.",
+    "expected_result": 2
+  },
+  {
+    "id": "array_fill_assign",
+    "prompt": "Task: write correct Curlee code for a module-level `static` fixed-size Int array `[Int; 5]` named `vals` holding 10,20,30,40,50 in order, and `main()` that returns the value at index 2. Remember: array literals are repeat-fill only -- use fill-then-assign.",
+    "expected_result": 30
+  },
+  {
+    "id": "loop_contract",
+    "prompt": "Task: write a Curlee function `sum_to(n: Int) -> Int` with contract `requires n >= 0` and `ensures result >= 0`, using a bounded while loop with invariant/decreases to sum 1..n. Have `main()` return `sum_to(5)`.",
+    "expected_result": 15
+  }
+]


### PR DESCRIPTION
## Summary
Three related deliverables from tonight's independent LLM-writability work, all verified against a real build before being committed:

1. **`docs/llm-system-prompt.md`** (#237) — a self-contained syntax reference for an LLM's system prompt. Includes two pieces of guidance not in `.roo/rules/rules.md`, found from real failures while fine-tuning a local model on this exact syntax (write-up on #240): the `decreases` direction requirement for ascending vs descending loops, and nested `if`/`else` over early-return chains for functions proving an `ensures` postcondition.

2. **`examples/llm-few-shot/`** (#238) — 16 files (14 accepted + 2 rejected) covering contracts, structs, enums, arrays, capabilities, bitwise ops — not the fuzz-generated arithmetic in `tests/correct_samples/`. Includes the two rejected-program examples the issue explicitly asks for (array out-of-bounds, an unsatisfiable `ensures` caught by Z3), each with its exact real diagnostic output in the header comment.

3. **`scripts/llm_validation_loop.py`** (#239) — a generate → `curlee check`/`run` → pass-rate harness against any OpenAI-chat-completions-compatible endpoint. Includes a 5-task starter set at `tests/llm_validation/tasks.json`.

## Verification
- Every code snippet and example individually run/checked against a real build, output observed.
- The two rejected examples' documented diagnostic output matches the real `curlee check` output exactly.
- `scripts/llm_validation_loop.py` tested end-to-end against a real local model: 4/5, the one failure being a genuine model imperfection the harness correctly caught.

## Related
Findings and results write-up: #240.